### PR TITLE
Refactor state-manager

### DIFF
--- a/rollups-node/Cargo.lock
+++ b/rollups-node/Cargo.lock
@@ -2797,9 +2797,10 @@ dependencies = [
 name = "rollups-state-manager"
 version = "0.1.0"
 dependencies = [
- "anyhow",
+ "lazy_static",
  "rusqlite",
  "rusqlite_migration",
+ "thiserror",
 ]
 
 [[package]]

--- a/rollups-node/Cargo.toml
+++ b/rollups-node/Cargo.toml
@@ -31,4 +31,5 @@ async-trait = "0.1.74"
 ethers = "2.0.11"
 futures = "0.3"
 log = "0.4"
+thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/rollups-node/blockchain-reader/src/lib.rs
+++ b/rollups-node/blockchain-reader/src/lib.rs
@@ -99,7 +99,7 @@ impl<E: EthEvent> BlockchainReader<E> {
         Ok(vec![])
     }
 
-    pub async fn start(&mut self, _s: Arc<dyn StateManager>) -> Result<()> {
+    pub async fn start<SM: StateManager>(&mut self, _s: Arc<SM>) -> Result<()> {
         // instantiate
         // ```
         // read from DB the block of the most recent processed

--- a/rollups-node/state-manager/Cargo.toml
+++ b/rollups-node/state-manager/Cargo.toml
@@ -11,6 +11,8 @@ readme = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.6"
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 rusqlite_migration = "1.2.0"
+
+lazy_static = "1.4.0"
+thiserror = { workspace = true }

--- a/rollups-node/state-manager/src/lib.rs
+++ b/rollups-node/state-manager/src/lib.rs
@@ -1,130 +1,98 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-use anyhow::Result;
-use rusqlite::Connection;
-use rusqlite_migration::{Migrations, M};
+pub mod persistent_state_access;
+
+pub(crate) mod sql;
+
+use std::error::Error;
+
+pub type Blob = Vec<u8>;
+
+#[derive(Clone, Debug)]
+pub struct InputId {
+    pub epoch_number: u64,
+    pub input_index_in_epoch: u64,
+}
+
+impl Default for InputId {
+    fn default() -> Self {
+        Self {
+            epoch_number: 0,
+            input_index_in_epoch: 0,
+        }
+    }
+}
+
+impl InputId {
+    pub fn increment_index(self) -> Self {
+        Self {
+            epoch_number: self.epoch_number,
+            input_index_in_epoch: self.input_index_in_epoch + 1,
+        }
+    }
+
+    pub fn increment_epoch(self) -> Self {
+        Self {
+            epoch_number: self.epoch_number + 1,
+            input_index_in_epoch: 0,
+        }
+    }
+
+    pub fn validate_next(&self, next: &Self) -> bool {
+        match self {
+            InputId {
+                epoch_number,
+                input_index_in_epoch,
+            } if next.epoch_number == *epoch_number
+                && next.input_index_in_epoch == input_index_in_epoch + 1 =>
+            {
+                true
+            }
+
+            InputId { epoch_number, .. }
+                if next.epoch_number > *epoch_number && next.input_index_in_epoch == 0 =>
+            {
+                true
+            }
+
+            _ => false,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Input {
+    pub id: InputId,
+    pub data: Blob,
+}
+
+#[derive(Clone, Debug)]
+pub struct Epoch {
+    pub epoch_number: u64,
+    pub block_sealed: u64,
+}
 
 pub trait StateManager {
-    fn add_epoch(&self, epoch_number: u64) -> Result<()>;
-    fn add_input(&self, input: &[u8], epoch_number: u64, input_index_in_epoch: u64) -> Result<()>;
-    fn add_machine_state_hash(
+    type Error: Error;
+
+    //
+    // Consensus Data
+    //
+
+    fn epoch_count(&self) -> Result<u64, Self::Error>;
+    fn input(&self, id: &InputId) -> Result<Option<Input>, Self::Error>;
+    fn insert_consensus_data<'a>(
         &self,
-        machine_state_hash: &[u8],
-        epoch_number: u64,
-        input_index_in_epoch: u64,
-        _repetitions: u64,
-    ) -> Result<()>;
-    fn add_snapshot(&self, path: &str, epoch_number: u64, input_index_in_epoch: u64) -> Result<()>;
-    fn epoch(&self) -> Result<u64>;
-    fn input(&self, epoch_number: u64, input_index_in_epoch: u64) -> Result<Option<Vec<u8>>>;
-    fn latest_block(&self) -> Result<Option<u64>>;
-    fn latest_snapshot(&self) -> Result<Option<(String, u64, u64)>>;
-    fn machine_state_hash(&self, epoch_number: u64, input_index_in_epoch: u64) -> Result<Vec<u8>>;
-    fn set_latest_block(&self, block: u64) -> Result<()>;
-}
+        last_processed_block: u64,
+        inputs: impl Iterator<Item = &'a Input>,
+        epochs: impl Iterator<Item = &'a Epoch>,
+    ) -> Result<(), Self::Error>;
+    fn latest_processed_block(&self) -> Result<u64, Self::Error>;
 
-pub struct SqliteStateManager {
-    connection: Connection,
-}
-
-impl SqliteStateManager {
-    pub fn connect(database_uri: &str) -> Result<Self> {
-        let mut connection = Connection::open(database_uri)?;
-        let migrations = Migrations::new(vec![
-            M::up(
-                "CREATE TABLE constants (
-                    key TEXT NOT NULL PRIMARY KEY,
-                    value TEXT NOT NULL
-                );",
-            ),
-            M::up(
-                "CREATE TABLE epochs (
-                    epoch_number INTEGER NOT NULL PRIMARY KEY,
-                    block_sealed INTEGER NOT NULL,
-                    settled BOOLEAN NOT NULL
-                );",
-            ),
-            M::up(
-                "CREATE TABLE inputs (
-                    epoch_number INTEGER NOT NULL,
-                    input_index_in_epoch INTEGER NOT NULL,
-                    input BLOB NOT NULL,
-                    PRIMARY KEY (epoch_number, input_index_in_epoch)
-                );",
-            ),
-            M::up(
-                "CREATE TABLE machine_state_hashes (
-                    epoch_number INTEGER NOT NULL,
-                    input_index_in_epoch INTEGER NOT NULL,
-                    machine_state_hash BLOB NOT NULL,
-                    PRIMARY KEY (epoch_number, input_index_in_epoch)
-                );",
-            ),
-            M::up(
-                "CREATE TABLE snapshots (
-                    epoch_number INTEGER NOT NULL,
-                    input_index_in_epoch INTEGER NOT NULL,
-                    path TEXT NOT NULL,
-                    PRIMARY KEY (epoch_number, input_index_in_epoch)
-                );",
-            ),
-        ]);
-        migrations.to_latest(&mut connection)?;
-
-        Ok(Self { connection })
-    }
-}
-
-impl StateManager for SqliteStateManager {
-    fn add_input(&self, input: &[u8], epoch_number: u64, input_index_in_epoch: u64) -> Result<()> {
-        // to keep the integrity of the inputs table, an input is only inserted when
-        // 1. no input from later epoch exists
-        // 2. all prior inputs of the same epoch are added
-        let mut sttm = self
-            .connection
-            .prepare("SELECT count(*) FROM inputs WHERE epoch_number > ?1")?;
-
-        match sttm.query([epoch_number])?.next()? {
-            Some(r) => {
-                let count_of_inputs: u64 = r.get(0)?;
-                if count_of_inputs > 0 {
-                    return Err(anyhow::anyhow!("inputs from later epochs are found"));
-                }
-            }
-            None => {
-                return Err(anyhow::anyhow!("fail to get count(*) from epoch check"));
-            }
-        }
-
-        let mut sttm = self.connection.prepare(
-            "SELECT count(*) FROM inputs WHERE epoch_number = ?1 AND input_index_in_epoch < ?2",
-        )?;
-
-        match sttm.query([epoch_number, input_index_in_epoch])?.next()? {
-            Some(r) => {
-                let count_of_inputs: u64 = r.get(0)?;
-                if count_of_inputs != input_index_in_epoch {
-                    return Err(anyhow::anyhow!("missing inputs before the current one"));
-                }
-            }
-            None => {
-                return Err(anyhow::anyhow!(
-                    "fail to get count(*) from input index check"
-                ));
-            }
-        }
-
-        let mut sttm = self.connection.prepare(
-            "
-                INSERT INTO inputs (epoch_number, input_index_in_epoch, input) VALUES (?1, ?2, ?3)",
-        )?;
-
-        if sttm.execute((epoch_number, input_index_in_epoch, input))? != 1 {
-            return Err(anyhow::anyhow!("input insertion failed"));
-        }
-        Ok(())
-    }
+    //
+    // Rollup Data
+    //
 
     fn add_machine_state_hash(
         &self,
@@ -132,297 +100,17 @@ impl StateManager for SqliteStateManager {
         epoch_number: u64,
         input_index_in_epoch: u64,
         _repetitions: u64,
-    ) -> Result<()> {
-        // add machine state hash
-        // 1. successful if the row doesn't exist
-        // 2. do nothing if it exists and the state hash is the same
-        // 3. return error if it exists with different state hash
-
-        // TODO:
-        // If it already exists, it shouldn't be an error (maybe just an assert)
-        // Abstractly, for each epoch and each input in epoch, there's an array of state hashes.
-        // This means we add an extra column called "index" or "computation_hash" index, which
-        // resets after every input.
-        // So we could read the last index for that epoch+input, and add a new row with the next
-        // index.
-        // Furthermore, besides the state hash itself, we have to add the number of
-        // repetitions of that state hash.
-
-        let mut sttm = self
-            .connection
-            .prepare("SELECT * FROM machine_state_hashes WHERE epoch_number = ?1 AND input_index_in_epoch = ?2")?;
-
-        match sttm.query([epoch_number, input_index_in_epoch])?.next()? {
-            Some(r) => {
-                let read_machine_state_hash: Vec<u8> = r.get(0)?;
-                if read_machine_state_hash != machine_state_hash.to_vec() {
-                    return Err(anyhow::anyhow!(
-                        "different machine state hash exists for the same key"
-                    ));
-                }
-            }
-            None => {
-                // machine state hash doesn't exist
-            }
-        }
-
-        let mut sttm = self.connection.prepare(
-            "INSERT INTO machine_state_hashes (epoch_number, input_index_in_epoch, machine_state_hash) VALUES (?1, ?2, ?3)",
-        )?;
-
-        if sttm.execute((epoch_number, input_index_in_epoch, machine_state_hash))? != 1 {
-            return Err(anyhow::anyhow!("machine state hash insertion failed"));
-        }
-        Ok(())
-    }
-
-    fn add_snapshot(&self, path: &str, epoch_number: u64, input_index_in_epoch: u64) -> Result<()> {
-        let mut sttm = self.connection.prepare(
-            "INSERT INTO snapshots (epoch_number, input_index_in_epoch, path) VALUES (?1, ?2, ?3)",
-        )?;
-
-        if sttm.execute((epoch_number, input_index_in_epoch, path))? != 1 {
-            return Err(anyhow::anyhow!("machine snapshot insertion failed"));
-        }
-        Ok(())
-    }
-
-    fn add_epoch(&self, epoch_number: u64) -> Result<()> {
-        Ok(())
-    }
-
-    fn epoch(&self) -> Result<u64> {
-        Ok(0)
-    }
-    fn input(&self, epoch_number: u64, input_index_in_epoch: u64) -> Result<Option<Vec<u8>>> {
-        let mut sttm = self.connection.prepare(
-            "SELECT input FROM inputs WHERE epoch_number = ?1 AND input_index_in_epoch = ?2",
-        )?;
-        let mut query = sttm.query([epoch_number, input_index_in_epoch])?;
-
-        match query.next()? {
-            Some(r) => {
-                let input = r.get(0)?;
-                Ok(input)
-            }
-            None => Ok(None),
-        }
-    }
-
-    fn machine_state_hash(&self, epoch_number: u64, input_index_in_epoch: u64) -> Result<Vec<u8>> {
-        let mut sttm = self
-            .connection
-            .prepare("SELECT * FROM machine_state_hashes WHERE epoch_number = ?1 AND input_index_in_epoch = ?2")?;
-        let mut query = sttm.query([epoch_number, input_index_in_epoch])?;
-
-        match query.next()? {
-            Some(r) => {
-                let state = r.get(0)?;
-                return Ok(state);
-            }
-            None => {
-                return Err(anyhow::anyhow!("machine state hash doesn't exist"));
-            }
-        }
-    }
-
-    fn latest_snapshot(&self) -> Result<Option<(String, u64, u64)>> {
-        let mut sttm = self.connection.prepare(
-            "SELECT epoch_number, input_index_in_epoch, path FROM snapshots \
-                ORDER BY \
-                    epoch_number DESC, \
-                    input_index_in_epoch DESC \
-                LIMIT 1",
-        )?;
-        let mut query = sttm.query([])?;
-
-        match query.next()? {
-            Some(r) => {
-                let epoch_number = r.get(0)?;
-                let input_index_in_epoch = r.get(1)?;
-                let path = r.get(2)?;
-
-                Ok(Some((path, epoch_number, input_index_in_epoch)))
-            }
-            None => Ok(None),
-        }
-    }
-
-    fn set_latest_block(&self, block: u64) -> Result<()> {
-        let mut sttm = self
-            .connection
-            .prepare("INSERT OR REPLACE INTO constants (key, value) VALUES (?1, ?2)")?;
-
-        if sttm.execute(("latest_block", block))? != 1 {
-            return Err(anyhow::anyhow!("fail to update latest processed block"));
-        }
-        Ok(())
-    }
-
-    fn latest_block(&self) -> Result<Option<u64>> {
-        let mut sttm = self.connection.prepare(
-            "SELECT value FROM constants \
-                WHERE key = ?1 ",
-        )?;
-        let mut query = sttm.query(["latest_block"])?;
-
-        match query.next()? {
-            Some(r) => {
-                let latest_block: u64 = r.get::<_, String>(0)?.parse()?;
-
-                Ok(Some(latest_block))
-            }
-            None => Ok(None),
-        }
-    }
-}
-
-#[test]
-
-fn test_state_manager() -> Result<()> {
-    let db_path = "/tmp/test.db";
-
-    let input_0_bytes = b"hello";
-    let input_1_bytes = b"world";
-
-    {
-        let manager = SqliteStateManager::connect(db_path)?;
-
-        manager.add_input(input_0_bytes, 0, 0)?;
-        manager.add_input(input_1_bytes, 0, 1)?;
-
-        assert_eq!(
-            manager.input(0, 0)?,
-            Some(input_0_bytes.to_vec()),
-            "input 0 bytes should match"
-        );
-        assert_eq!(
-            manager.input(0, 1)?,
-            Some(input_1_bytes.to_vec()),
-            "input 1 bytes should match"
-        );
-        assert_eq!(manager.input(0, 2)?, None, "input 2 shouldn't exist");
-
-        assert_eq!(
-            manager.add_input(input_0_bytes, 0, 1).is_err(),
-            true,
-            "duplicate input index should fail"
-        );
-        assert_eq!(
-            manager.add_input(input_1_bytes, 0, 3).is_err(),
-            true,
-            "input index should be sequential"
-        );
-        assert_eq!(
-            manager.add_input(input_1_bytes, 0, 2).is_ok(),
-            true,
-            "add sequential input should succeed"
-        );
-
-        assert_eq!(
-            manager.latest_block()?.is_none(),
-            true,
-            "latest block should be empty"
-        );
-
-        let latest_block = 20;
-
-        manager.set_latest_block(latest_block)?;
-
-        assert_eq!(
-            manager.latest_block()?.expect("latest block should exists"),
-            latest_block,
-            "latest block should match"
-        );
-
-        assert_eq!(
-            manager.latest_snapshot()?.is_none(),
-            true,
-            "latest snapshot should be empty"
-        );
-
-        let (latest_snapshot, epoch_number, input_index_in_epoch) = ("AAA", 0, 0);
-
-        manager.add_snapshot(latest_snapshot, epoch_number, input_index_in_epoch)?;
-
-        assert_eq!(
-            manager
-                .latest_snapshot()?
-                .expect("latest snapshot should exists"),
-            (
-                latest_snapshot.to_string(),
-                epoch_number,
-                input_index_in_epoch
-            ),
-            "latest snapshot should match"
-        );
-
-        let (latest_snapshot, epoch_number, input_index_in_epoch) = ("BBB", 0, 1);
-
-        manager.add_snapshot(latest_snapshot, epoch_number, input_index_in_epoch)?;
-
-        assert_eq!(
-            manager
-                .latest_snapshot()?
-                .expect("latest snapshot should exists"),
-            (
-                latest_snapshot.to_string(),
-                epoch_number,
-                input_index_in_epoch
-            ),
-            "latest snapshot should match"
-        );
-
-        let (latest_snapshot, epoch_number, input_index_in_epoch) = ("CCC", 0, 2);
-
-        manager.add_snapshot(latest_snapshot, epoch_number, input_index_in_epoch)?;
-
-        assert_eq!(
-            manager
-                .latest_snapshot()?
-                .expect("latest snapshot should exists"),
-            (
-                latest_snapshot.to_string(),
-                epoch_number,
-                input_index_in_epoch
-            ),
-            "latest snapshot should match"
-        );
-
-        let (latest_snapshot, epoch_number, input_index_in_epoch) = ("DDD", 3, 1);
-
-        manager.add_snapshot(latest_snapshot, epoch_number, input_index_in_epoch)?;
-
-        assert_eq!(
-            manager
-                .latest_snapshot()?
-                .expect("latest snapshot should exists"),
-            (
-                latest_snapshot.to_string(),
-                epoch_number,
-                input_index_in_epoch
-            ),
-            "latest snapshot should match"
-        );
-
-        manager.add_snapshot("EEE", 0, 4)?;
-
-        assert_eq!(
-            manager
-                .latest_snapshot()?
-                .expect("latest snapshot should exists"),
-            (
-                latest_snapshot.to_string(),
-                epoch_number,
-                input_index_in_epoch
-            ),
-            "latest snapshot should match"
-        );
-    }
-
-    // manager should be dropped when it goes out of scope
-    // delete `test.db`
-    std::fs::remove_file(db_path)?;
-
-    Ok(())
+    ) -> Result<(), Self::Error>;
+    fn machine_state_hash(
+        &self,
+        epoch_number: u64,
+        input_index_in_epoch: u64,
+    ) -> Result<Vec<u8>, Self::Error>;
+    fn add_snapshot(
+        &self,
+        path: &str,
+        epoch_number: u64,
+        input_index_in_epoch: u64,
+    ) -> Result<(), Self::Error>;
+    fn latest_snapshot(&self) -> Result<Option<(String, u64, u64)>, Self::Error>;
 }

--- a/rollups-node/state-manager/src/persistent_state_access.rs
+++ b/rollups-node/state-manager/src/persistent_state_access.rs
@@ -1,0 +1,389 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+use crate::{Epoch, Input, InputId, StateManager};
+
+use crate::sql::{consensus_data, error::*, migrations};
+
+use rusqlite::Connection;
+
+pub struct PersistentStateAccess {
+    connection: Connection,
+}
+
+impl PersistentStateAccess {
+    pub fn new(mut connection: Connection) -> std::result::Result<Self, rusqlite_migration::Error> {
+        migrations::migrate_to_latest(&mut connection).unwrap();
+        Ok(Self { connection })
+    }
+}
+
+impl StateManager for PersistentStateAccess {
+    type Error = PersistentStateAccessError;
+
+    //
+    // Consensus Data
+    //
+
+    fn epoch_count(&self) -> Result<u64> {
+        consensus_data::epoch_count(&self.connection)
+    }
+
+    fn input(&self, id: &InputId) -> Result<Option<Input>> {
+        consensus_data::input(&self.connection, id)
+    }
+
+    fn latest_processed_block(&self) -> Result<u64> {
+        consensus_data::last_processed_block(&self.connection)
+    }
+
+    fn insert_consensus_data<'a>(
+        &self,
+        last_processed_block: u64,
+        inputs: impl Iterator<Item = &'a Input>,
+        epochs: impl Iterator<Item = &'a Epoch>,
+    ) -> Result<()> {
+        let tx = self.connection.unchecked_transaction()?;
+        consensus_data::update_last_processed_block(&tx, last_processed_block)?;
+        consensus_data::insert_inputs(&tx, inputs)?;
+        consensus_data::insert_epochs(&tx, epochs)?;
+        tx.commit()?;
+
+        Ok(())
+    }
+
+    //
+    // Rollup Data
+    //
+
+    fn add_machine_state_hash(
+        &self,
+        machine_state_hash: &[u8],
+        epoch_number: u64,
+        input_index_in_epoch: u64,
+        _repetitions: u64,
+    ) -> Result<()> {
+        // add machine state hash
+        // 1. successful if the row doesn't exist
+        // 2. do nothing if it exists and the state hash is the same
+        // 3. return error if it exists with different state hash
+
+        // TODO:
+        // If it already exists, it shouldn't be an error (maybe just an assert)
+        // Abstractly, for each epoch and each input in epoch, there's an array of state hashes.
+        // This means we add an extra column called "index" or "computation_hash" index, which
+        // resets after every input.
+        // So we could read the last index for that epoch+input, and add a new row with the next
+        // index.
+        // Furthermore, besides the state hash itself, we have to add the number of
+        // repetitions of that state hash.
+
+        let mut sttm = self
+            .connection
+            .prepare("SELECT * FROM machine_state_hashes WHERE epoch_number = ?1 AND input_index_in_epoch = ?2")?;
+
+        match sttm.query([epoch_number, input_index_in_epoch])?.next()? {
+            Some(r) => {
+                let read_machine_state_hash: Vec<u8> = r.get(0)?;
+                if read_machine_state_hash != machine_state_hash.to_vec() {
+                    return Err(PersistentStateAccessError::DuplicateEntry {
+                        description: "different machine state hash exists for the same key"
+                            .to_owned(),
+                    });
+                }
+            }
+            None => {
+                // machine state hash doesn't exist
+            }
+        }
+
+        let mut sttm = self.connection.prepare(
+            "INSERT INTO machine_state_hashes (epoch_number, input_index_in_epoch, machine_state_hash) VALUES (?1, ?2, ?3)",
+        )?;
+
+        if sttm.execute((epoch_number, input_index_in_epoch, machine_state_hash))? != 1 {
+            return Err(PersistentStateAccessError::InsertionFailed {
+                description: "machine state hash insertion failed".to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    fn add_snapshot(&self, path: &str, epoch_number: u64, input_index_in_epoch: u64) -> Result<()> {
+        let mut sttm = self.connection.prepare(
+            "INSERT INTO snapshots (epoch_number, input_index_in_epoch, path) VALUES (?1, ?2, ?3)",
+        )?;
+
+        if sttm.execute((epoch_number, input_index_in_epoch, path))? != 1 {
+            return Err(PersistentStateAccessError::InsertionFailed {
+                description: "machine snapshot insertion failed".to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    fn machine_state_hash(&self, epoch_number: u64, input_index_in_epoch: u64) -> Result<Vec<u8>> {
+        let mut sttm = self
+            .connection
+            .prepare("SELECT * FROM machine_state_hashes WHERE epoch_number = ?1 AND input_index_in_epoch = ?2")?;
+        let mut query = sttm.query([epoch_number, input_index_in_epoch])?;
+
+        match query.next()? {
+            Some(r) => {
+                let state = r.get(0)?;
+                return Ok(state);
+            }
+            None => {
+                return Err(PersistentStateAccessError::DataNotFound {
+                    description: "machine state hash doesn't exist".to_owned(),
+                });
+            }
+        }
+    }
+
+    fn latest_snapshot(&self) -> Result<Option<(String, u64, u64)>> {
+        let mut sttm = self.connection.prepare(
+            "SELECT epoch_number, input_index_in_epoch, path FROM snapshots \
+                ORDER BY \
+                    epoch_number DESC, \
+                    input_index_in_epoch DESC \
+                LIMIT 1",
+        )?;
+        let mut query = sttm.query([])?;
+
+        match query.next()? {
+            Some(r) => {
+                let epoch_number = r.get(0)?;
+                let input_index_in_epoch = r.get(1)?;
+                let path = r.get(2)?;
+
+                Ok(Some((path, epoch_number, input_index_in_epoch)))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::*;
+
+    pub fn setup() -> PersistentStateAccess {
+        let conn = Connection::open_in_memory().unwrap();
+        let access = PersistentStateAccess::new(conn).unwrap();
+        access
+    }
+
+    #[test]
+    fn test_state_access() -> super::Result<()> {
+        let input_0_bytes = b"hello";
+        let input_1_bytes = b"world";
+
+        let access = setup();
+
+        // access.add_input(input_0_bytes, 0, 0)?;
+        // access.add_input(input_1_bytes, 0, 1)?;
+
+        access.insert_consensus_data(
+            20,
+            [
+                &Input {
+                    id: InputId {
+                        epoch_number: 0,
+                        input_index_in_epoch: 0,
+                    },
+                    data: input_0_bytes.to_vec(),
+                },
+                &Input {
+                    id: InputId {
+                        epoch_number: 0,
+                        input_index_in_epoch: 1,
+                    },
+                    data: input_1_bytes.to_vec(),
+                },
+            ]
+            .into_iter(),
+            [&Epoch {
+                epoch_number: 0,
+                block_sealed: 12,
+            }]
+            .into_iter(),
+        )?;
+
+        assert_eq!(
+            access
+                .input(&InputId {
+                    epoch_number: 0,
+                    input_index_in_epoch: 0
+                })?
+                .map(|x| x.data),
+            Some(input_0_bytes.to_vec()),
+            "input 0 bytes should match"
+        );
+        assert_eq!(
+            access
+                .input(&InputId {
+                    epoch_number: 0,
+                    input_index_in_epoch: 1
+                })?
+                .map(|x| x.data),
+            Some(input_1_bytes.to_vec()),
+            "input 1 bytes should match"
+        );
+        assert!(
+            access
+                .input(&InputId {
+                    epoch_number: 0,
+                    input_index_in_epoch: 2
+                })?
+                .is_none(),
+            "input 2 shouldn't exist"
+        );
+
+        assert!(
+            access
+                .insert_consensus_data(
+                    21,
+                    [&Input {
+                        id: InputId {
+                            epoch_number: 0,
+                            input_index_in_epoch: 1,
+                        },
+                        data: input_0_bytes.to_vec(),
+                    }]
+                    .into_iter(),
+                    [].into_iter().into_iter(),
+                )
+                .is_err(),
+            "duplicate input index should fail"
+        );
+        assert!(
+            access
+                .insert_consensus_data(
+                    21,
+                    [&Input {
+                        id: InputId {
+                            epoch_number: 0,
+                            input_index_in_epoch: 3,
+                        },
+                        data: input_0_bytes.to_vec(),
+                    }]
+                    .into_iter(),
+                    [].into_iter().into_iter(),
+                )
+                .is_err(),
+            "input index should be sequential"
+        );
+        assert!(
+            access
+                .insert_consensus_data(
+                    21,
+                    [&Input {
+                        id: InputId {
+                            epoch_number: 0,
+                            input_index_in_epoch: 2,
+                        },
+                        data: input_1_bytes.to_vec(),
+                    }]
+                    .into_iter(),
+                    [].into_iter().into_iter(),
+                )
+                .is_ok(),
+            "add sequential input should succeed"
+        );
+
+        assert_eq!(
+            access.latest_processed_block()?,
+            21,
+            "latest block should match"
+        );
+
+        assert_eq!(
+            access.latest_snapshot()?.is_none(),
+            true,
+            "latest snapshot should be empty"
+        );
+
+        let (latest_snapshot, epoch_number, input_index_in_epoch) = ("AAA", 0, 0);
+
+        access.add_snapshot(latest_snapshot, epoch_number, input_index_in_epoch)?;
+
+        assert_eq!(
+            access
+                .latest_snapshot()?
+                .expect("latest snapshot should exists"),
+            (
+                latest_snapshot.to_string(),
+                epoch_number,
+                input_index_in_epoch
+            ),
+            "latest snapshot should match"
+        );
+
+        let (latest_snapshot, epoch_number, input_index_in_epoch) = ("BBB", 0, 1);
+
+        access.add_snapshot(latest_snapshot, epoch_number, input_index_in_epoch)?;
+
+        assert_eq!(
+            access
+                .latest_snapshot()?
+                .expect("latest snapshot should exists"),
+            (
+                latest_snapshot.to_string(),
+                epoch_number,
+                input_index_in_epoch
+            ),
+            "latest snapshot should match"
+        );
+
+        let (latest_snapshot, epoch_number, input_index_in_epoch) = ("CCC", 0, 2);
+
+        access.add_snapshot(latest_snapshot, epoch_number, input_index_in_epoch)?;
+
+        assert_eq!(
+            access
+                .latest_snapshot()?
+                .expect("latest snapshot should exists"),
+            (
+                latest_snapshot.to_string(),
+                epoch_number,
+                input_index_in_epoch
+            ),
+            "latest snapshot should match"
+        );
+
+        let (latest_snapshot, epoch_number, input_index_in_epoch) = ("DDD", 3, 1);
+
+        access.add_snapshot(latest_snapshot, epoch_number, input_index_in_epoch)?;
+
+        assert_eq!(
+            access
+                .latest_snapshot()?
+                .expect("latest snapshot should exists"),
+            (
+                latest_snapshot.to_string(),
+                epoch_number,
+                input_index_in_epoch
+            ),
+            "latest snapshot should match"
+        );
+
+        access.add_snapshot("EEE", 0, 4)?;
+
+        assert_eq!(
+            access
+                .latest_snapshot()?
+                .expect("latest snapshot should exists"),
+            (
+                latest_snapshot.to_string(),
+                epoch_number,
+                input_index_in_epoch
+            ),
+            "latest snapshot should match"
+        );
+
+        Ok(())
+    }
+}

--- a/rollups-node/state-manager/src/sql/consensus_data.rs
+++ b/rollups-node/state-manager/src/sql/consensus_data.rs
@@ -1,0 +1,538 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+use super::error::*;
+use crate::{Epoch, Input, InputId};
+
+use rusqlite::{params, OptionalExtension};
+
+//
+// Last Processed
+//
+
+pub fn update_last_processed_block(conn: &rusqlite::Connection, block: u64) -> Result<()> {
+    let previous = last_processed_block(conn)?;
+
+    if previous >= block {
+        return Err(PersistentStateAccessError::InconsistentLastProcessed {
+            last: previous,
+            provided: block,
+        });
+    }
+
+    conn.execute(
+        "UPDATE latest_processed SET block = ?1 WHERE id = 1",
+        params![block],
+    )?;
+    Ok(())
+}
+
+pub fn last_processed_block(conn: &rusqlite::Connection) -> Result<u64> {
+    Ok(conn.query_row(
+        "\
+        SELECT block FROM latest_processed WHERE id = 1
+        ",
+        [],
+        |r| r.get(0),
+    )?)
+}
+
+//
+// Inputs
+//
+
+fn validate_insert(current: &Option<InputId>, next: &InputId) -> bool {
+    match &current {
+        Some(i) if !i.validate_next(&next) => false,
+        None if next.input_index_in_epoch != 0 => false,
+        _ => true,
+    }
+}
+
+pub fn insert_inputs<'a>(
+    conn: &rusqlite::Connection,
+    inputs: impl Iterator<Item = &'a Input>,
+) -> Result<()> {
+    let mut inputs = inputs.peekable();
+    if inputs.peek().is_none() {
+        return Ok(());
+    }
+
+    let mut current_input = last_input(&conn)?;
+
+    let mut stmt = insert_input_statement(&conn)?;
+    for input in inputs {
+        if !validate_insert(&current_input, &input.id) {
+            return Err(PersistentStateAccessError::InconsistentInput {
+                previous: current_input,
+                provided: input.id.clone(),
+            });
+        }
+
+        stmt.execute(params![
+            input.id.epoch_number,
+            input.id.input_index_in_epoch,
+            input.data
+        ])?;
+        current_input = Some(input.id.clone());
+    }
+
+    Ok(())
+}
+
+fn insert_input_statement<'a>(conn: &'a rusqlite::Connection) -> Result<rusqlite::Statement<'a>> {
+    Ok(conn.prepare(
+        "\
+        INSERT INTO inputs (epoch_number, input_index_in_epoch, input) VALUES (?1, ?2, ?3)
+        ",
+    )?)
+}
+
+pub fn last_input(conn: &rusqlite::Connection) -> Result<Option<InputId>> {
+    let mut stmt = conn.prepare(
+        "\
+        SELECT epoch_number, input_index_in_epoch FROM inputs
+        ORDER BY epoch_number DESC, input_index_in_epoch DESC
+        LIMIT 1
+        ",
+    )?;
+
+    Ok(stmt
+        .query_row([], |row| {
+            Ok(InputId {
+                epoch_number: row.get(0)?,
+                input_index_in_epoch: row.get(1)?,
+            })
+        })
+        .optional()?)
+}
+
+pub fn input(conn: &rusqlite::Connection, id: &InputId) -> Result<Option<Input>> {
+    let mut stmt = conn.prepare(
+        "\
+        SELECT * FROM inputs
+        WHERE epoch_number = ?1 AND input_index_in_epoch = ?2
+        ",
+    )?;
+
+    let i = stmt
+        .query_row(params![id.epoch_number, id.input_index_in_epoch], |row| {
+            Ok(Input {
+                id: id.clone(),
+                data: row.get(2)?,
+            })
+        })
+        .optional()?;
+
+    Ok(i)
+}
+
+//
+// Epochs
+//
+
+pub fn insert_epochs<'a>(
+    conn: &rusqlite::Connection,
+    epochs: impl Iterator<Item = &'a Epoch>,
+) -> Result<()> {
+    let mut epochs = epochs.peekable();
+    if epochs.peek().is_none() {
+        return Ok(());
+    }
+
+    let mut next_epoch = epoch_count(&conn)?;
+
+    let mut stmt = insert_epoch_statement(&conn)?;
+    for epoch in epochs {
+        if epoch.epoch_number != next_epoch {
+            return Err(PersistentStateAccessError::InconsistentEpoch {
+                expected: next_epoch,
+                provided: epoch.epoch_number,
+            });
+        }
+
+        stmt.execute(params![epoch.epoch_number, epoch.block_sealed])?;
+        next_epoch += 1;
+    }
+    Ok(())
+}
+
+fn insert_epoch_statement<'a>(conn: &'a rusqlite::Connection) -> Result<rusqlite::Statement<'a>> {
+    Ok(conn.prepare(
+        "\
+        INSERT INTO epochs (epoch_number, block_sealed) VALUES (?1, ?2)
+        ",
+    )?)
+}
+
+pub fn epoch_count<'a>(conn: &'a rusqlite::Connection) -> Result<u64> {
+    Ok(conn.query_row(
+        "\
+        SELECT MAX(epoch_number) FROM epochs
+        ",
+        [],
+        |row| {
+            let x: Option<u64> = row.get(0)?;
+            Ok(x.map(|x: u64| x + 1).unwrap_or(0))
+        },
+    )?)
+}
+
+//
+// Tests
+//
+
+#[cfg(test)]
+mod test_helper {
+    use crate::sql::migrations;
+    use rusqlite::Connection;
+
+    pub fn setup_db() -> Connection {
+        let mut conn = Connection::open_in_memory().unwrap();
+        migrations::MIGRATIONS.to_latest(&mut conn).unwrap();
+        conn
+    }
+}
+
+#[cfg(test)]
+mod last_processed_block_tests {
+    use super::*;
+
+    #[test]
+    fn test_last_processed_block() {
+        let conn = test_helper::setup_db();
+
+        assert!(matches!(
+            update_last_processed_block(&conn, 0),
+            Err(PersistentStateAccessError::InconsistentLastProcessed {
+                last: 0,
+                provided: 0
+            })
+        ));
+
+        update_last_processed_block(&conn, 1).unwrap();
+        assert!(matches!(last_processed_block(&conn), Ok(1)));
+
+        assert!(matches!(
+            update_last_processed_block(&conn, 0),
+            Err(PersistentStateAccessError::InconsistentLastProcessed {
+                last: 1,
+                provided: 0
+            })
+        ));
+        assert!(matches!(
+            update_last_processed_block(&conn, 1),
+            Err(PersistentStateAccessError::InconsistentLastProcessed {
+                last: 1,
+                provided: 1
+            })
+        ));
+
+        update_last_processed_block(&conn, 200).unwrap();
+        assert!(matches!(last_processed_block(&conn), Ok(200)));
+    }
+}
+
+#[cfg(test)]
+mod inputs_tests {
+    use super::*;
+
+    #[test]
+    fn test_empty() {
+        let conn = test_helper::setup_db();
+        assert!(matches!(last_input(&conn), Ok(None)));
+        assert!(matches!(input(&conn, &InputId::default()), Ok(None)));
+    }
+
+    #[test]
+    fn test_insert() {
+        let conn = test_helper::setup_db();
+        let data = vec![1];
+
+        assert!(matches!(
+            insert_inputs(
+                &conn,
+                [&Input {
+                    id: InputId {
+                        epoch_number: 0,
+                        input_index_in_epoch: 0
+                    },
+                    data: data.clone(),
+                }]
+                .into_iter(),
+            ),
+            Ok(())
+        ));
+
+        assert!(matches!(
+            last_input(&conn),
+            Ok(Some(InputId {
+                epoch_number: 0,
+                input_index_in_epoch: 0
+            }))
+        ));
+        assert!(matches!(
+            input(
+                &conn,
+                &InputId {
+                    epoch_number: 0,
+                    input_index_in_epoch: 0
+                },
+            ),
+            Ok(Some(Input {
+                id: InputId {
+                    epoch_number: 0,
+                    input_index_in_epoch: 0
+                },
+                ..
+            }))
+        ));
+
+        assert!(matches!(
+            insert_inputs(
+                &conn,
+                [
+                    &Input {
+                        id: InputId {
+                            epoch_number: 0,
+                            input_index_in_epoch: 1
+                        },
+                        data: data.clone(),
+                    },
+                    &Input {
+                        id: InputId {
+                            epoch_number: 0,
+                            input_index_in_epoch: 2
+                        },
+                        data: data.clone(),
+                    },
+                    &Input {
+                        id: InputId {
+                            epoch_number: 1,
+                            input_index_in_epoch: 0
+                        },
+                        data: data.clone(),
+                    },
+                    &Input {
+                        id: InputId {
+                            epoch_number: 3,
+                            input_index_in_epoch: 0
+                        },
+                        data: data.clone(),
+                    }
+                ]
+                .into_iter(),
+            ),
+            Ok(())
+        ));
+        assert!(matches!(
+            last_input(&conn),
+            Ok(Some(InputId {
+                epoch_number: 3,
+                input_index_in_epoch: 0
+            }))
+        ));
+        assert!(matches!(
+            input(
+                &conn,
+                &InputId {
+                    epoch_number: 0,
+                    input_index_in_epoch: 2
+                },
+            ),
+            Ok(Some(Input {
+                id: InputId {
+                    epoch_number: 0,
+                    input_index_in_epoch: 2
+                },
+                ..
+            }))
+        ));
+    }
+
+    #[test]
+    fn test_inconsistent_insert() {
+        let conn = test_helper::setup_db();
+        let data = vec![1];
+
+        assert!(matches!(
+            insert_inputs(
+                &conn,
+                [&Input {
+                    id: InputId {
+                        epoch_number: 0,
+                        input_index_in_epoch: 1
+                    },
+                    data: data.clone(),
+                }]
+                .into_iter(),
+            ),
+            Err(_)
+        ));
+        assert!(matches!(
+            insert_inputs(
+                &conn,
+                [&Input {
+                    id: InputId {
+                        epoch_number: 1,
+                        input_index_in_epoch: 1
+                    },
+                    data: data.clone(),
+                }]
+                .into_iter(),
+            ),
+            Err(_)
+        ));
+
+        assert!(matches!(last_input(&conn), Ok(None)));
+        assert!(matches!(
+            input(
+                &conn,
+                &InputId {
+                    epoch_number: 0,
+                    input_index_in_epoch: 1
+                },
+            ),
+            Ok(None)
+        ));
+
+        assert!(matches!(
+            insert_inputs(
+                &conn,
+                [
+                    &Input {
+                        id: InputId {
+                            epoch_number: 0,
+                            input_index_in_epoch: 0
+                        },
+                        data: data.clone(),
+                    },
+                    &Input {
+                        id: InputId {
+                            epoch_number: 0,
+                            input_index_in_epoch: 2
+                        },
+                        data: data.clone(),
+                    },
+                ]
+                .into_iter(),
+            ),
+            Err(_)
+        ));
+        assert!(matches!(
+            last_input(&conn),
+            Ok(Some(InputId {
+                epoch_number: 0,
+                input_index_in_epoch: 0
+            }))
+        ));
+        assert!(matches!(
+            input(
+                &conn,
+                &InputId {
+                    epoch_number: 0,
+                    input_index_in_epoch: 0
+                },
+            ),
+            Ok(Some(Input {
+                id: InputId {
+                    epoch_number: 0,
+                    input_index_in_epoch: 0
+                },
+                ..
+            }))
+        ));
+    }
+}
+
+#[cfg(test)]
+mod epochs_tests {
+    use super::*;
+
+    #[test]
+    fn test_epoch() {
+        let conn = test_helper::setup_db();
+
+        assert!(matches!(epoch_count(&conn), Ok(0)));
+
+        assert!(matches!(
+            insert_epochs(
+                &conn,
+                [&Epoch {
+                    epoch_number: 1,
+                    block_sealed: 0,
+                }]
+                .into_iter(),
+            ),
+            Err(PersistentStateAccessError::InconsistentEpoch {
+                expected: 0,
+                provided: 1
+            })
+        ));
+        assert!(matches!(epoch_count(&conn), Ok(0)));
+
+        assert!(matches!(
+            insert_epochs(
+                &conn,
+                [&Epoch {
+                    epoch_number: 0,
+                    block_sealed: 0,
+                }]
+                .into_iter(),
+            ),
+            Ok(())
+        ));
+        assert!(matches!(epoch_count(&conn), Ok(1)));
+
+        assert!(matches!(
+            insert_epochs(
+                &conn,
+                [&Epoch {
+                    epoch_number: 0,
+                    block_sealed: 0,
+                }]
+                .into_iter(),
+            ),
+            Err(PersistentStateAccessError::InconsistentEpoch {
+                expected: 1,
+                provided: 0
+            })
+        ));
+        assert!(matches!(epoch_count(&conn), Ok(1)));
+
+        let x: Vec<_> = (1..128)
+            .map(|i| Epoch {
+                epoch_number: i,
+                block_sealed: 0,
+            })
+            .collect();
+        assert!(matches!(insert_epochs(&conn, x.iter()), Ok(())));
+        assert!(matches!(epoch_count(&conn), Ok(128)));
+
+        assert!(matches!(
+            insert_epochs(
+                &conn,
+                [
+                    &Epoch {
+                        epoch_number: 128,
+                        block_sealed: 0,
+                    },
+                    &Epoch {
+                        epoch_number: 129,
+                        block_sealed: 0,
+                    },
+                    &Epoch {
+                        epoch_number: 131,
+                        block_sealed: 0,
+                    }
+                ]
+                .into_iter(),
+            ),
+            Err(PersistentStateAccessError::InconsistentEpoch {
+                expected: 130,
+                provided: 131
+            })
+        ));
+        assert!(matches!(epoch_count(&conn), Ok(130)));
+    }
+}

--- a/rollups-node/state-manager/src/sql/error.rs
+++ b/rollups-node/state-manager/src/sql/error.rs
@@ -1,0 +1,42 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+use thiserror::Error;
+
+use crate::InputId;
+
+#[derive(Error, Debug)]
+pub enum PersistentStateAccessError {
+    #[error(transparent)]
+    SQLite {
+        #[from]
+        source: rusqlite::Error,
+    },
+
+    #[error("Supplied block `{provided}` is smaller than last processed `{last}`")]
+    InconsistentLastProcessed { last: u64, provided: u64 },
+
+    #[error("Supplied Epoch is inconsistent: expected `{expected}`, got `{provided}`")]
+    InconsistentEpoch { expected: u64, provided: u64 },
+
+    #[error(
+        "Supplied Input is inconsistent: previous is `{:?}`, got `{:?}`",
+        previous,
+        provided
+    )]
+    InconsistentInput {
+        previous: Option<InputId>,
+        provided: InputId,
+    },
+
+    #[error("Duplicate entry: `{description}`")]
+    DuplicateEntry { description: String },
+
+    #[error("Failed to insert data: `{description}`")]
+    InsertionFailed { description: String },
+
+    #[error("Couldn't find data: `{description}`")]
+    DataNotFound { description: String },
+}
+
+pub type Result<T> = std::result::Result<T, PersistentStateAccessError>;

--- a/rollups-node/state-manager/src/sql/migrations.rs
+++ b/rollups-node/state-manager/src/sql/migrations.rs
@@ -1,0 +1,12 @@
+use lazy_static::lazy_static;
+use rusqlite::Connection;
+use rusqlite_migration::{Migrations, M};
+
+lazy_static! {
+    pub static ref MIGRATIONS: Migrations<'static> =
+        Migrations::new(vec![M::up(include_str!("migrations.sql")),]);
+}
+
+pub fn migrate_to_latest(conn: &mut Connection) -> Result<(), rusqlite_migration::Error> {
+    MIGRATIONS.to_latest(conn)
+}

--- a/rollups-node/state-manager/src/sql/migrations.sql
+++ b/rollups-node/state-manager/src/sql/migrations.sql
@@ -1,0 +1,31 @@
+CREATE TABLE epochs (
+    epoch_number INTEGER NOT NULL PRIMARY KEY,
+    block_sealed INTEGER NOT NULL
+);
+
+CREATE TABLE inputs (
+    epoch_number INTEGER NOT NULL,
+    input_index_in_epoch INTEGER NOT NULL,
+    input BLOB NOT NULL,
+    PRIMARY KEY (epoch_number, input_index_in_epoch)
+);
+
+CREATE TABLE latest_processed (
+    id INTEGER NOT NULL PRIMARY KEY,
+    block INTEGER NOT NULL
+);
+INSERT INTO latest_processed (id, block) VALUES (1, 0);
+
+CREATE TABLE machine_state_hashes (
+    epoch_number INTEGER NOT NULL,
+    input_index_in_epoch INTEGER NOT NULL,
+    machine_state_hash BLOB NOT NULL,
+    PRIMARY KEY (epoch_number, input_index_in_epoch)
+);
+
+CREATE TABLE snapshots (
+  epoch_number INTEGER NOT NULL,
+  input_index_in_epoch INTEGER NOT NULL,
+  path TEXT NOT NULL,
+  PRIMARY KEY (epoch_number, input_index_in_epoch)
+);

--- a/rollups-node/state-manager/src/sql/mod.rs
+++ b/rollups-node/state-manager/src/sql/mod.rs
@@ -1,0 +1,3 @@
+pub mod consensus_data;
+pub mod error;
+pub mod migrations;


### PR DESCRIPTION
Create dedicated input, input id, and epoch types. Make latest_block, inputs and epochs atomic writes. Use thiserror instead of anyhow.