### PR TITLE
chore: refactor contract interfaces

### DIFF
--- a/prt/compute-rs/core/src/contract/leaf_tournament.rs
+++ b/prt/compute-rs/core/src/contract/leaf_tournament.rs
@@ -524,38 +524,6 @@ pub mod leaf_tournament {
                     ],
                 ),
                 (
-                    ::std::borrow::ToOwned::to_owned("matchAdvanced"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Event {
-                            name: ::std::borrow::ToOwned::to_owned("matchAdvanced"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("parent"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: false,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("left"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: false,
-                                },
-                            ],
-                            anonymous: false,
-                        },
-                    ],
-                ),
-                (
                     ::std::borrow::ToOwned::to_owned("matchCreated"),
                     ::std::vec![
                         ::ethers::core::abi::ethabi::Event {
@@ -772,16 +740,6 @@ pub mod leaf_tournament {
         > {
             self.0.event()
         }
-        ///Gets the contract's `matchAdvanced` event
-        pub fn match_advanced_filter(
-            &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            MatchAdvancedFilter,
-        > {
-            self.0.event()
-        }
         ///Gets the contract's `matchCreated` event
         pub fn match_created_filter(
             &self,
@@ -833,23 +791,6 @@ pub mod leaf_tournament {
         Eq,
         Hash
     )]
-    #[ethevent(name = "matchAdvanced", abi = "matchAdvanced(bytes32,bytes32,bytes32)")]
-    pub struct MatchAdvancedFilter {
-        #[ethevent(indexed)]
-        pub p0: [u8; 32],
-        pub parent: [u8; 32],
-        pub left: [u8; 32],
-    }
-    #[derive(
-        Clone,
-        ::ethers::contract::EthEvent,
-        ::ethers::contract::EthDisplay,
-        Default,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash
-    )]
     #[ethevent(name = "matchCreated", abi = "matchCreated(bytes32,bytes32,bytes32)")]
     pub struct MatchCreatedFilter {
         #[ethevent(indexed)]
@@ -862,7 +803,6 @@ pub mod leaf_tournament {
     #[derive(Clone, ::ethers::contract::EthAbiType, Debug, PartialEq, Eq, Hash)]
     pub enum LeafTournamentEvents {
         CommitmentJoinedFilter(CommitmentJoinedFilter),
-        MatchAdvancedFilter(MatchAdvancedFilter),
         MatchCreatedFilter(MatchCreatedFilter),
     }
     impl ::ethers::contract::EthLogDecode for LeafTournamentEvents {
@@ -871,9 +811,6 @@ pub mod leaf_tournament {
         ) -> ::core::result::Result<Self, ::ethers::core::abi::Error> {
             if let Ok(decoded) = CommitmentJoinedFilter::decode_log(log) {
                 return Ok(LeafTournamentEvents::CommitmentJoinedFilter(decoded));
-            }
-            if let Ok(decoded) = MatchAdvancedFilter::decode_log(log) {
-                return Ok(LeafTournamentEvents::MatchAdvancedFilter(decoded));
             }
             if let Ok(decoded) = MatchCreatedFilter::decode_log(log) {
                 return Ok(LeafTournamentEvents::MatchCreatedFilter(decoded));
@@ -887,9 +824,6 @@ pub mod leaf_tournament {
                 Self::CommitmentJoinedFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
                 }
-                Self::MatchAdvancedFilter(element) => {
-                    ::core::fmt::Display::fmt(element, f)
-                }
                 Self::MatchCreatedFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
                 }
@@ -899,11 +833,6 @@ pub mod leaf_tournament {
     impl ::core::convert::From<CommitmentJoinedFilter> for LeafTournamentEvents {
         fn from(value: CommitmentJoinedFilter) -> Self {
             Self::CommitmentJoinedFilter(value)
-        }
-    }
-    impl ::core::convert::From<MatchAdvancedFilter> for LeafTournamentEvents {
-        fn from(value: MatchAdvancedFilter) -> Self {
-            Self::MatchAdvancedFilter(value)
         }
     }
     impl ::core::convert::From<MatchCreatedFilter> for LeafTournamentEvents {

--- a/prt/compute-rs/core/src/contract/non_leaf_tournament.rs
+++ b/prt/compute-rs/core/src/contract/non_leaf_tournament.rs
@@ -518,38 +518,6 @@ pub mod non_leaf_tournament {
                     ],
                 ),
                 (
-                    ::std::borrow::ToOwned::to_owned("matchAdvanced"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Event {
-                            name: ::std::borrow::ToOwned::to_owned("matchAdvanced"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("parent"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: false,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("left"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: false,
-                                },
-                            ],
-                            anonymous: false,
-                        },
-                    ],
-                ),
-                (
                     ::std::borrow::ToOwned::to_owned("matchCreated"),
                     ::std::vec![
                         ::ethers::core::abi::ethabi::Event {
@@ -788,16 +756,6 @@ pub mod non_leaf_tournament {
         > {
             self.0.event()
         }
-        ///Gets the contract's `matchAdvanced` event
-        pub fn match_advanced_filter(
-            &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            MatchAdvancedFilter,
-        > {
-            self.0.event()
-        }
         ///Gets the contract's `matchCreated` event
         pub fn match_created_filter(
             &self,
@@ -859,23 +817,6 @@ pub mod non_leaf_tournament {
         Eq,
         Hash
     )]
-    #[ethevent(name = "matchAdvanced", abi = "matchAdvanced(bytes32,bytes32,bytes32)")]
-    pub struct MatchAdvancedFilter {
-        #[ethevent(indexed)]
-        pub p0: [u8; 32],
-        pub parent: [u8; 32],
-        pub left: [u8; 32],
-    }
-    #[derive(
-        Clone,
-        ::ethers::contract::EthEvent,
-        ::ethers::contract::EthDisplay,
-        Default,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash
-    )]
     #[ethevent(name = "matchCreated", abi = "matchCreated(bytes32,bytes32,bytes32)")]
     pub struct MatchCreatedFilter {
         #[ethevent(indexed)]
@@ -904,7 +845,6 @@ pub mod non_leaf_tournament {
     #[derive(Clone, ::ethers::contract::EthAbiType, Debug, PartialEq, Eq, Hash)]
     pub enum NonLeafTournamentEvents {
         CommitmentJoinedFilter(CommitmentJoinedFilter),
-        MatchAdvancedFilter(MatchAdvancedFilter),
         MatchCreatedFilter(MatchCreatedFilter),
         NewInnerTournamentFilter(NewInnerTournamentFilter),
     }
@@ -914,9 +854,6 @@ pub mod non_leaf_tournament {
         ) -> ::core::result::Result<Self, ::ethers::core::abi::Error> {
             if let Ok(decoded) = CommitmentJoinedFilter::decode_log(log) {
                 return Ok(NonLeafTournamentEvents::CommitmentJoinedFilter(decoded));
-            }
-            if let Ok(decoded) = MatchAdvancedFilter::decode_log(log) {
-                return Ok(NonLeafTournamentEvents::MatchAdvancedFilter(decoded));
             }
             if let Ok(decoded) = MatchCreatedFilter::decode_log(log) {
                 return Ok(NonLeafTournamentEvents::MatchCreatedFilter(decoded));
@@ -933,9 +870,6 @@ pub mod non_leaf_tournament {
                 Self::CommitmentJoinedFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
                 }
-                Self::MatchAdvancedFilter(element) => {
-                    ::core::fmt::Display::fmt(element, f)
-                }
                 Self::MatchCreatedFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
                 }
@@ -948,11 +882,6 @@ pub mod non_leaf_tournament {
     impl ::core::convert::From<CommitmentJoinedFilter> for NonLeafTournamentEvents {
         fn from(value: CommitmentJoinedFilter) -> Self {
             Self::CommitmentJoinedFilter(value)
-        }
-    }
-    impl ::core::convert::From<MatchAdvancedFilter> for NonLeafTournamentEvents {
-        fn from(value: MatchAdvancedFilter) -> Self {
-            Self::MatchAdvancedFilter(value)
         }
     }
     impl ::core::convert::From<MatchCreatedFilter> for NonLeafTournamentEvents {

--- a/prt/compute-rs/core/src/contract/non_root_tournament.rs
+++ b/prt/compute-rs/core/src/contract/non_root_tournament.rs
@@ -451,38 +451,6 @@ pub mod non_root_tournament {
                     ],
                 ),
                 (
-                    ::std::borrow::ToOwned::to_owned("matchAdvanced"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Event {
-                            name: ::std::borrow::ToOwned::to_owned("matchAdvanced"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("parent"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: false,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("left"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: false,
-                                },
-                            ],
-                            anonymous: false,
-                        },
-                    ],
-                ),
-                (
                     ::std::borrow::ToOwned::to_owned("matchCreated"),
                     ::std::vec![
                         ::ethers::core::abi::ethabi::Event {
@@ -676,16 +644,6 @@ pub mod non_root_tournament {
         > {
             self.0.event()
         }
-        ///Gets the contract's `matchAdvanced` event
-        pub fn match_advanced_filter(
-            &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            MatchAdvancedFilter,
-        > {
-            self.0.event()
-        }
         ///Gets the contract's `matchCreated` event
         pub fn match_created_filter(
             &self,
@@ -737,23 +695,6 @@ pub mod non_root_tournament {
         Eq,
         Hash
     )]
-    #[ethevent(name = "matchAdvanced", abi = "matchAdvanced(bytes32,bytes32,bytes32)")]
-    pub struct MatchAdvancedFilter {
-        #[ethevent(indexed)]
-        pub p0: [u8; 32],
-        pub parent: [u8; 32],
-        pub left: [u8; 32],
-    }
-    #[derive(
-        Clone,
-        ::ethers::contract::EthEvent,
-        ::ethers::contract::EthDisplay,
-        Default,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash
-    )]
     #[ethevent(name = "matchCreated", abi = "matchCreated(bytes32,bytes32,bytes32)")]
     pub struct MatchCreatedFilter {
         #[ethevent(indexed)]
@@ -766,7 +707,6 @@ pub mod non_root_tournament {
     #[derive(Clone, ::ethers::contract::EthAbiType, Debug, PartialEq, Eq, Hash)]
     pub enum NonRootTournamentEvents {
         CommitmentJoinedFilter(CommitmentJoinedFilter),
-        MatchAdvancedFilter(MatchAdvancedFilter),
         MatchCreatedFilter(MatchCreatedFilter),
     }
     impl ::ethers::contract::EthLogDecode for NonRootTournamentEvents {
@@ -775,9 +715,6 @@ pub mod non_root_tournament {
         ) -> ::core::result::Result<Self, ::ethers::core::abi::Error> {
             if let Ok(decoded) = CommitmentJoinedFilter::decode_log(log) {
                 return Ok(NonRootTournamentEvents::CommitmentJoinedFilter(decoded));
-            }
-            if let Ok(decoded) = MatchAdvancedFilter::decode_log(log) {
-                return Ok(NonRootTournamentEvents::MatchAdvancedFilter(decoded));
             }
             if let Ok(decoded) = MatchCreatedFilter::decode_log(log) {
                 return Ok(NonRootTournamentEvents::MatchCreatedFilter(decoded));
@@ -791,9 +728,6 @@ pub mod non_root_tournament {
                 Self::CommitmentJoinedFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
                 }
-                Self::MatchAdvancedFilter(element) => {
-                    ::core::fmt::Display::fmt(element, f)
-                }
                 Self::MatchCreatedFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
                 }
@@ -803,11 +737,6 @@ pub mod non_root_tournament {
     impl ::core::convert::From<CommitmentJoinedFilter> for NonRootTournamentEvents {
         fn from(value: CommitmentJoinedFilter) -> Self {
             Self::CommitmentJoinedFilter(value)
-        }
-    }
-    impl ::core::convert::From<MatchAdvancedFilter> for NonRootTournamentEvents {
-        fn from(value: MatchAdvancedFilter) -> Self {
-            Self::MatchAdvancedFilter(value)
         }
     }
     impl ::core::convert::From<MatchCreatedFilter> for NonRootTournamentEvents {

--- a/prt/compute-rs/core/src/contract/root_tournament.rs
+++ b/prt/compute-rs/core/src/contract/root_tournament.rs
@@ -449,38 +449,6 @@ pub mod root_tournament {
                     ],
                 ),
                 (
-                    ::std::borrow::ToOwned::to_owned("matchAdvanced"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Event {
-                            name: ::std::borrow::ToOwned::to_owned("matchAdvanced"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("parent"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: false,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("left"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: false,
-                                },
-                            ],
-                            anonymous: false,
-                        },
-                    ],
-                ),
-                (
                     ::std::borrow::ToOwned::to_owned("matchCreated"),
                     ::std::vec![
                         ::ethers::core::abi::ethabi::Event {
@@ -674,16 +642,6 @@ pub mod root_tournament {
         > {
             self.0.event()
         }
-        ///Gets the contract's `matchAdvanced` event
-        pub fn match_advanced_filter(
-            &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            MatchAdvancedFilter,
-        > {
-            self.0.event()
-        }
         ///Gets the contract's `matchCreated` event
         pub fn match_created_filter(
             &self,
@@ -735,23 +693,6 @@ pub mod root_tournament {
         Eq,
         Hash
     )]
-    #[ethevent(name = "matchAdvanced", abi = "matchAdvanced(bytes32,bytes32,bytes32)")]
-    pub struct MatchAdvancedFilter {
-        #[ethevent(indexed)]
-        pub p0: [u8; 32],
-        pub parent: [u8; 32],
-        pub left: [u8; 32],
-    }
-    #[derive(
-        Clone,
-        ::ethers::contract::EthEvent,
-        ::ethers::contract::EthDisplay,
-        Default,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash
-    )]
     #[ethevent(name = "matchCreated", abi = "matchCreated(bytes32,bytes32,bytes32)")]
     pub struct MatchCreatedFilter {
         #[ethevent(indexed)]
@@ -764,7 +705,6 @@ pub mod root_tournament {
     #[derive(Clone, ::ethers::contract::EthAbiType, Debug, PartialEq, Eq, Hash)]
     pub enum RootTournamentEvents {
         CommitmentJoinedFilter(CommitmentJoinedFilter),
-        MatchAdvancedFilter(MatchAdvancedFilter),
         MatchCreatedFilter(MatchCreatedFilter),
     }
     impl ::ethers::contract::EthLogDecode for RootTournamentEvents {
@@ -773,9 +713,6 @@ pub mod root_tournament {
         ) -> ::core::result::Result<Self, ::ethers::core::abi::Error> {
             if let Ok(decoded) = CommitmentJoinedFilter::decode_log(log) {
                 return Ok(RootTournamentEvents::CommitmentJoinedFilter(decoded));
-            }
-            if let Ok(decoded) = MatchAdvancedFilter::decode_log(log) {
-                return Ok(RootTournamentEvents::MatchAdvancedFilter(decoded));
             }
             if let Ok(decoded) = MatchCreatedFilter::decode_log(log) {
                 return Ok(RootTournamentEvents::MatchCreatedFilter(decoded));
@@ -789,9 +726,6 @@ pub mod root_tournament {
                 Self::CommitmentJoinedFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
                 }
-                Self::MatchAdvancedFilter(element) => {
-                    ::core::fmt::Display::fmt(element, f)
-                }
                 Self::MatchCreatedFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
                 }
@@ -801,11 +735,6 @@ pub mod root_tournament {
     impl ::core::convert::From<CommitmentJoinedFilter> for RootTournamentEvents {
         fn from(value: CommitmentJoinedFilter) -> Self {
             Self::CommitmentJoinedFilter(value)
-        }
-    }
-    impl ::core::convert::From<MatchAdvancedFilter> for RootTournamentEvents {
-        fn from(value: MatchAdvancedFilter) -> Self {
-            Self::MatchAdvancedFilter(value)
         }
     }
     impl ::core::convert::From<MatchCreatedFilter> for RootTournamentEvents {

--- a/prt/compute-rs/core/src/contract/tournament.rs
+++ b/prt/compute-rs/core/src/contract/tournament.rs
@@ -411,38 +411,6 @@ pub mod tournament {
                     ],
                 ),
                 (
-                    ::std::borrow::ToOwned::to_owned("matchAdvanced"),
-                    ::std::vec![
-                        ::ethers::core::abi::ethabi::Event {
-                            name: ::std::borrow::ToOwned::to_owned("matchAdvanced"),
-                            inputs: ::std::vec![
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::string::String::new(),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: true,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("parent"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: false,
-                                },
-                                ::ethers::core::abi::ethabi::EventParam {
-                                    name: ::std::borrow::ToOwned::to_owned("left"),
-                                    kind: ::ethers::core::abi::ethabi::ParamType::FixedBytes(
-                                        32usize,
-                                    ),
-                                    indexed: false,
-                                },
-                            ],
-                            anonymous: false,
-                        },
-                    ],
-                ),
-                (
                     ::std::borrow::ToOwned::to_owned("matchCreated"),
                     ::std::vec![
                         ::ethers::core::abi::ethabi::Event {
@@ -626,16 +594,6 @@ pub mod tournament {
         > {
             self.0.event()
         }
-        ///Gets the contract's `matchAdvanced` event
-        pub fn match_advanced_filter(
-            &self,
-        ) -> ::ethers::contract::builders::Event<
-            ::std::sync::Arc<M>,
-            M,
-            MatchAdvancedFilter,
-        > {
-            self.0.event()
-        }
         ///Gets the contract's `matchCreated` event
         pub fn match_created_filter(
             &self,
@@ -687,23 +645,6 @@ pub mod tournament {
         Eq,
         Hash
     )]
-    #[ethevent(name = "matchAdvanced", abi = "matchAdvanced(bytes32,bytes32,bytes32)")]
-    pub struct MatchAdvancedFilter {
-        #[ethevent(indexed)]
-        pub p0: [u8; 32],
-        pub parent: [u8; 32],
-        pub left: [u8; 32],
-    }
-    #[derive(
-        Clone,
-        ::ethers::contract::EthEvent,
-        ::ethers::contract::EthDisplay,
-        Default,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash
-    )]
     #[ethevent(name = "matchCreated", abi = "matchCreated(bytes32,bytes32,bytes32)")]
     pub struct MatchCreatedFilter {
         #[ethevent(indexed)]
@@ -716,7 +657,6 @@ pub mod tournament {
     #[derive(Clone, ::ethers::contract::EthAbiType, Debug, PartialEq, Eq, Hash)]
     pub enum TournamentEvents {
         CommitmentJoinedFilter(CommitmentJoinedFilter),
-        MatchAdvancedFilter(MatchAdvancedFilter),
         MatchCreatedFilter(MatchCreatedFilter),
     }
     impl ::ethers::contract::EthLogDecode for TournamentEvents {
@@ -725,9 +665,6 @@ pub mod tournament {
         ) -> ::core::result::Result<Self, ::ethers::core::abi::Error> {
             if let Ok(decoded) = CommitmentJoinedFilter::decode_log(log) {
                 return Ok(TournamentEvents::CommitmentJoinedFilter(decoded));
-            }
-            if let Ok(decoded) = MatchAdvancedFilter::decode_log(log) {
-                return Ok(TournamentEvents::MatchAdvancedFilter(decoded));
             }
             if let Ok(decoded) = MatchCreatedFilter::decode_log(log) {
                 return Ok(TournamentEvents::MatchCreatedFilter(decoded));
@@ -741,9 +678,6 @@ pub mod tournament {
                 Self::CommitmentJoinedFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
                 }
-                Self::MatchAdvancedFilter(element) => {
-                    ::core::fmt::Display::fmt(element, f)
-                }
                 Self::MatchCreatedFilter(element) => {
                     ::core::fmt::Display::fmt(element, f)
                 }
@@ -753,11 +687,6 @@ pub mod tournament {
     impl ::core::convert::From<CommitmentJoinedFilter> for TournamentEvents {
         fn from(value: CommitmentJoinedFilter) -> Self {
             Self::CommitmentJoinedFilter(value)
-        }
-    }
-    impl ::core::convert::From<MatchAdvancedFilter> for TournamentEvents {
-        fn from(value: MatchAdvancedFilter) -> Self {
-            Self::MatchAdvancedFilter(value)
         }
     }
     impl ::core::convert::From<MatchCreatedFilter> for TournamentEvents {

--- a/prt/compute-rs/dave-compute/src/main.rs
+++ b/prt/compute-rs/dave-compute/src/main.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
     const ANVIL_URL: &str = "http://127.0.0.1:8545";
     const ANVIL_CHAIN_ID: u64 = 31337;
     const ANVIL_KEY_1: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
-    const ANVIL_ROOT_TOURNAMENT: &str = "0xcafac3dd18ac6c6e92c921884f9e4176737c052c";
+    const ANVIL_ROOT_TOURNAMENT: &str = "0xa16E02E87b7454126E5E10d957A927A7F5B5d2be";
 
     env_logger::init();
     let web3_rpc_url = var("URL").unwrap_or(String::from(ANVIL_URL));

--- a/prt/contracts/script/TopTournament.s.sol
+++ b/prt/contracts/script/TopTournament.s.sol
@@ -7,20 +7,19 @@ import {Script} from "forge-std/Script.sol";
 
 import {Machine} from "src/Machine.sol";
 
-import "src/tournament/factories/TournamentFactory.sol";
+import "src/tournament/factories/MultiLevelTournamentFactory.sol";
 
 contract TopTournamentScript is Script {
     function run(Machine.Hash initialHash) external {
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
 
-        TournamentFactory factory = new TournamentFactory(
-            new SingleLevelTournamentFactory(),
+        MultiLevelTournamentFactory factory = new MultiLevelTournamentFactory(
             new TopTournamentFactory(),
             new MiddleTournamentFactory(),
             new BottomTournamentFactory()
         );
 
-        factory.instantiateTop(initialHash);
+        factory.instantiateRoot(initialHash);
 
         vm.stopBroadcast();
     }

--- a/prt/contracts/src/tournament/abstracts/NonLeafTournament.sol
+++ b/prt/contracts/src/tournament/abstracts/NonLeafTournament.sol
@@ -3,8 +3,7 @@
 
 pragma solidity ^0.8.17;
 
-import "../factories/ITournamentFactory.sol";
-import "./Tournament.sol";
+import "../factories/IMultiLevelTournamentFactory.sol";
 import "./NonRootTournament.sol";
 
 /// @notice Non-leaf tournament can create inner tournaments and matches
@@ -21,7 +20,7 @@ abstract contract NonLeafTournament is Tournament {
     //
     // Constants
     //
-    ITournamentFactory immutable tournamentFactory;
+    IMultiLevelTournamentFactory immutable tournamentFactory;
 
     //
     // Storage
@@ -46,7 +45,7 @@ abstract contract NonLeafTournament is Tournament {
     //
     // Constructor
     //
-    constructor(ITournamentFactory _tournamentFactory) {
+    constructor(IMultiLevelTournamentFactory _tournamentFactory) {
         tournamentFactory = _tournamentFactory;
     }
 

--- a/prt/contracts/src/tournament/concretes/MiddleTournament.sol
+++ b/prt/contracts/src/tournament/concretes/MiddleTournament.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.17;
 import "../abstracts/NonLeafTournament.sol";
 import "../abstracts/NonRootTournament.sol";
 
-import "../factories/TournamentFactory.sol";
+import "../factories/IMultiLevelTournamentFactory.sol";
 
 /// @notice Middle tournament is non-top, non-bottom of a multi-level instance
 contract MiddleTournament is NonLeafTournament, NonRootTournament {
@@ -20,7 +20,7 @@ contract MiddleTournament is NonLeafTournament, NonRootTournament {
         uint256 _startCycle,
         uint64 _level,
         NonLeafTournament _parent,
-        TournamentFactory _tournamentFactory
+        IMultiLevelTournamentFactory _tournamentFactory
     )
         NonLeafTournament(_tournamentFactory)
         NonRootTournament(

--- a/prt/contracts/src/tournament/concretes/TopTournament.sol
+++ b/prt/contracts/src/tournament/concretes/TopTournament.sol
@@ -6,14 +6,14 @@ pragma solidity ^0.8.17;
 import "../abstracts/RootTournament.sol";
 import "../abstracts/NonLeafTournament.sol";
 
-import "../factories/TournamentFactory.sol";
+import "../factories/IMultiLevelTournamentFactory.sol";
 
 import "../../Machine.sol";
 
 /// @notice Top tournament of a multi-level instance
 contract TopTournament is NonLeafTournament, RootTournament {
-    constructor(Machine.Hash _initialHash, TournamentFactory _factory)
-        NonLeafTournament(_factory)
-        RootTournament(_initialHash)
-    {}
+    constructor(
+        Machine.Hash _initialHash,
+        IMultiLevelTournamentFactory _factory
+    ) NonLeafTournament(_factory) RootTournament(_initialHash) {}
 }

--- a/prt/contracts/src/tournament/factories/IMultiLevelTournamentFactory.sol
+++ b/prt/contracts/src/tournament/factories/IMultiLevelTournamentFactory.sol
@@ -1,0 +1,30 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+pragma solidity ^0.8.17;
+
+import "./ITournamentFactory.sol";
+
+interface IMultiLevelTournamentFactory is ITournamentFactory {
+    function instantiateMiddle(
+        Machine.Hash _initialHash,
+        Tree.Node _contestedCommitmentOne,
+        Machine.Hash _contestedFinalStateOne,
+        Tree.Node _contestedCommitmentTwo,
+        Machine.Hash _contestedFinalStateTwo,
+        Time.Duration _allowance,
+        uint256 _startCycle,
+        uint64 _level
+    ) external returns (Tournament);
+
+    function instantiateBottom(
+        Machine.Hash _initialHash,
+        Tree.Node _contestedCommitmentOne,
+        Machine.Hash _contestedFinalStateOne,
+        Tree.Node _contestedCommitmentTwo,
+        Machine.Hash _contestedFinalStateTwo,
+        Time.Duration _allowance,
+        uint256 _startCycle,
+        uint64 _level
+    ) external returns (Tournament);
+}

--- a/prt/contracts/src/tournament/factories/ITournamentFactory.sol
+++ b/prt/contracts/src/tournament/factories/ITournamentFactory.sol
@@ -3,38 +3,12 @@
 
 pragma solidity ^0.8.17;
 
-import "../abstracts/Tournament.sol";
+import "../abstracts/RootTournament.sol";
 
 interface ITournamentFactory {
-    event rootCreated(Tournament);
+    event rootCreated(RootTournament);
 
-    function instantiateSingleLevel(Machine.Hash _initialHash)
+    function instantiateRoot(Machine.Hash _initialHash)
         external
-        returns (Tournament);
-
-    function instantiateTop(Machine.Hash _initialHash)
-        external
-        returns (Tournament);
-
-    function instantiateMiddle(
-        Machine.Hash _initialHash,
-        Tree.Node _contestedCommitmentOne,
-        Machine.Hash _contestedFinalStateOne,
-        Tree.Node _contestedCommitmentTwo,
-        Machine.Hash _contestedFinalStateTwo,
-        Time.Duration _allowance,
-        uint256 _startCycle,
-        uint64 _level
-    ) external returns (Tournament);
-
-    function instantiateBottom(
-        Machine.Hash _initialHash,
-        Tree.Node _contestedCommitmentOne,
-        Machine.Hash _contestedFinalStateOne,
-        Tree.Node _contestedCommitmentTwo,
-        Machine.Hash _contestedFinalStateTwo,
-        Time.Duration _allowance,
-        uint256 _startCycle,
-        uint64 _level
-    ) external returns (Tournament);
+        returns (RootTournament);
 }

--- a/prt/contracts/src/tournament/factories/MiddleTournamentFactory.sol
+++ b/prt/contracts/src/tournament/factories/MiddleTournamentFactory.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.17;
 
-import "./TournamentFactory.sol";
+import "./MultiLevelTournamentFactory.sol";
 import "../abstracts/NonLeafTournament.sol";
 import "../concretes/MiddleTournament.sol";
 
@@ -35,7 +35,7 @@ contract MiddleTournamentFactory {
             _startCycle,
             _level,
             _parent,
-            TournamentFactory(msg.sender)
+            MultiLevelTournamentFactory(msg.sender)
         );
 
         return _tournament;

--- a/prt/contracts/src/tournament/factories/MultiLevelTournamentFactory.sol
+++ b/prt/contracts/src/tournament/factories/MultiLevelTournamentFactory.sol
@@ -3,24 +3,17 @@
 
 pragma solidity ^0.8.17;
 
-import "../concretes/TopTournament.sol";
-import "../concretes/MiddleTournament.sol";
-import "../concretes/BottomTournament.sol";
-import "../concretes/SingleLevelTournament.sol";
-
+import "./IMultiLevelTournamentFactory.sol";
 import "./TopTournamentFactory.sol";
 import "./MiddleTournamentFactory.sol";
 import "./BottomTournamentFactory.sol";
-import "./SingleLevelTournamentFactory.sol";
 
-contract TournamentFactory is ITournamentFactory {
-    SingleLevelTournamentFactory immutable singleLevelFactory;
+contract MultiLevelTournamentFactory is IMultiLevelTournamentFactory {
     TopTournamentFactory immutable topFactory;
     MiddleTournamentFactory immutable middleFactory;
     BottomTournamentFactory immutable bottomFactory;
 
     constructor(
-        SingleLevelTournamentFactory _singleLevelFactory,
         TopTournamentFactory _topFactory,
         MiddleTournamentFactory _middleFactory,
         BottomTournamentFactory _bottomFactory
@@ -28,27 +21,14 @@ contract TournamentFactory is ITournamentFactory {
         topFactory = _topFactory;
         middleFactory = _middleFactory;
         bottomFactory = _bottomFactory;
-        singleLevelFactory = _singleLevelFactory;
     }
 
-    function instantiateSingleLevel(Machine.Hash _initialHash)
+    function instantiateRoot(Machine.Hash _initialHash)
         external
         override
-        returns (Tournament)
+        returns (RootTournament)
     {
-        SingleLevelTournament _tournament =
-            singleLevelFactory.instantiate(_initialHash);
-        emit rootCreated(_tournament);
-
-        return _tournament;
-    }
-
-    function instantiateTop(Machine.Hash _initialHash)
-        external
-        override
-        returns (Tournament)
-    {
-        TopTournament _tournament = topFactory.instantiate(_initialHash);
+        RootTournament _tournament = topFactory.instantiate(_initialHash);
         emit rootCreated(_tournament);
 
         return _tournament;

--- a/prt/contracts/src/tournament/factories/SingleLevelTournamentFactory.sol
+++ b/prt/contracts/src/tournament/factories/SingleLevelTournamentFactory.sol
@@ -4,16 +4,19 @@
 pragma solidity ^0.8.17;
 
 import "../concretes/SingleLevelTournament.sol";
+import "./ITournamentFactory.sol";
 
-contract SingleLevelTournamentFactory {
+contract SingleLevelTournamentFactory is ITournamentFactory {
     constructor() {}
 
-    function instantiate(Machine.Hash _initialHash)
+    function instantiateRoot(Machine.Hash _initialHash)
         external
-        returns (SingleLevelTournament)
+        override
+        returns (RootTournament)
     {
         SingleLevelTournament _tournament =
             new SingleLevelTournament(_initialHash);
+        emit rootCreated(_tournament);
 
         return _tournament;
     }

--- a/prt/contracts/src/tournament/factories/TopTournamentFactory.sol
+++ b/prt/contracts/src/tournament/factories/TopTournamentFactory.sol
@@ -12,8 +12,9 @@ contract TopTournamentFactory {
         external
         returns (TopTournament)
     {
-        TopTournament _tournament =
-            new TopTournament(_initialHash, TournamentFactory(msg.sender));
+        TopTournament _tournament = new TopTournament(
+            _initialHash, IMultiLevelTournamentFactory(msg.sender)
+        );
 
         return _tournament;
     }

--- a/prt/contracts/test/MultiTournament.t.sol
+++ b/prt/contracts/test/MultiTournament.t.sol
@@ -13,7 +13,7 @@
 import "forge-std/Test.sol";
 
 import "./Util.sol";
-import "src/tournament/factories/TournamentFactory.sol";
+import "src/tournament/factories/MultiLevelTournamentFactory.sol";
 import "src/CanonicalConstants.sol";
 
 pragma solidity ^0.8.0;
@@ -25,7 +25,7 @@ contract MultiTournamentTest is Util, Test {
     using Match for Match.State;
     using Machine for Machine.Hash;
 
-    TournamentFactory immutable factory;
+    MultiLevelTournamentFactory immutable factory;
     TopTournament topTournament;
     MiddleTournament middleTournament;
     BottomTournament bottomTournament;
@@ -36,7 +36,7 @@ contract MultiTournamentTest is Util, Test {
     event newInnerTournament(Match.IdHash indexed, NonRootTournament);
 
     constructor() {
-        factory = Util.instantiateTournamentFactory();
+        factory = Util.instantiateMultiLevelTournamentFactory();
     }
 
     function setUp() public {}

--- a/prt/contracts/test/Tournament.t.sol
+++ b/prt/contracts/test/Tournament.t.sol
@@ -14,7 +14,7 @@ import "forge-std/console.sol";
 import "forge-std/Test.sol";
 
 import "./Util.sol";
-import "src/tournament/factories/TournamentFactory.sol";
+import "src/tournament/factories/MultiLevelTournamentFactory.sol";
 import "src/CanonicalConstants.sol";
 
 pragma solidity ^0.8.0;
@@ -25,7 +25,7 @@ contract TournamentTest is Util, Test {
     using Match for Match.Id;
     using Machine for Machine.Hash;
 
-    TournamentFactory immutable factory;
+    MultiLevelTournamentFactory immutable factory;
     TopTournament topTournament;
     MiddleTournament middleTournament;
 
@@ -35,7 +35,7 @@ contract TournamentTest is Util, Test {
     event newInnerTournament(Match.IdHash indexed, NonRootTournament);
 
     constructor() {
-        factory = Util.instantiateTournamentFactory();
+        factory = Util.instantiateMultiLevelTournamentFactory();
     }
 
     function setUp() public {}

--- a/prt/contracts/test/TournamentFactory.t.sol
+++ b/prt/contracts/test/TournamentFactory.t.sol
@@ -14,7 +14,8 @@ import "forge-std/console.sol";
 import "forge-std/Test.sol";
 
 import "src/tournament/abstracts/RootTournament.sol";
-import "src/tournament/factories/TournamentFactory.sol";
+import "src/tournament/factories/MultiLevelTournamentFactory.sol";
+import "src/tournament/factories/SingleLevelTournamentFactory.sol";
 import "src/CanonicalConstants.sol";
 
 import "./Util.sol";
@@ -22,15 +23,17 @@ import "./Util.sol";
 pragma solidity ^0.8.0;
 
 contract TournamentFactoryTest is Util, Test {
-    TournamentFactory factory;
+    MultiLevelTournamentFactory multi_factory;
+    SingleLevelTournamentFactory single_factory;
 
     function setUp() public {
-        factory = Util.instantiateTournamentFactory();
+        multi_factory = Util.instantiateMultiLevelTournamentFactory();
+        single_factory = new SingleLevelTournamentFactory();
     }
 
     function testRootTournament() public {
         RootTournament rootTournament = RootTournament(
-            address(factory.instantiateSingleLevel(Util.ONE_STATE))
+            address(single_factory.instantiateRoot(Util.ONE_STATE))
         );
 
         (uint64 _max_level, uint64 _level, uint64 _log2step, uint64 _height) =
@@ -46,8 +49,9 @@ contract TournamentFactoryTest is Util, Test {
             _height, ArbitrationConstants.height(_level), "height should match"
         );
 
-        rootTournament =
-            RootTournament(address(factory.instantiateTop(Util.ONE_STATE)));
+        rootTournament = RootTournament(
+            address(multi_factory.instantiateRoot(Util.ONE_STATE))
+        );
 
         (_max_level, _level, _log2step, _height) =
             rootTournament.tournamentLevelConstants();

--- a/prt/contracts/test/Util.sol
+++ b/prt/contracts/test/Util.sol
@@ -148,12 +148,12 @@ contract Util {
     }
 
     // create new _topTournament and player 0 joins it
-    function initializePlayer0Tournament(TournamentFactory _factory)
+    function initializePlayer0Tournament(MultiLevelTournamentFactory _factory)
         internal
         returns (TopTournament _topTournament)
     {
         _topTournament =
-            TopTournament(address(_factory.instantiateTop(ONE_STATE)));
+            TopTournament(address(_factory.instantiateRoot(ONE_STATE)));
         // player 0 joins tournament
         joinTournament(_topTournament, 0, 0);
     }
@@ -248,19 +248,17 @@ contract Util {
         );
     }
 
-    // instantiates all sub-factories and TournamentFactory
-    function instantiateTournamentFactory()
+    // instantiates all sub-factories and MultiLevelTournamentFactory
+    function instantiateMultiLevelTournamentFactory()
         internal
-        returns (TournamentFactory)
+        returns (MultiLevelTournamentFactory)
     {
-        SingleLevelTournamentFactory singleLevelFactory =
-            new SingleLevelTournamentFactory();
         TopTournamentFactory topFactory = new TopTournamentFactory();
         MiddleTournamentFactory middleFactory = new MiddleTournamentFactory();
         BottomTournamentFactory bottomFactory = new BottomTournamentFactory();
 
-        return new TournamentFactory(
-            singleLevelFactory, topFactory, middleFactory, bottomFactory
+        return new MultiLevelTournamentFactory(
+            topFactory, middleFactory, bottomFactory
         );
     }
 }

--- a/prt/lua_poc/blockchain/constants.lua
+++ b/prt/lua_poc/blockchain/constants.lua
@@ -1,7 +1,7 @@
 -- contains default 40 accounts of anvil test node
 local constants = {
     endpoint = "http://127.0.0.1:8545",
-    root_tournament = "0xcafac3dd18ac6c6e92c921884f9e4176737c052c",
+    root_tournament = "0xa16E02E87b7454126E5E10d957A927A7F5B5d2be",
     pks = {
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
         "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",


### PR DESCRIPTION
- split tournament factory into single/multi level
- update default top tournament for `lua_poc` and `dave-compute`
- update rust bindings of prt contracts