### PR TITLE
Fix grammatical error in the phrasing "committed it" in the doc

### DIFF
--- a/dave/README.md
+++ b/dave/README.md
@@ -11,4 +11,4 @@ This makes the system very inclusive and frees participants from having to pool 
 Finally, the maximum delay to finalization also grows only logarithmically with total adversarial expenditure, with the smallest multiplicative factor to date.
 In summary: the entire dispute completes in 2–5 challenge periods, the only way to break consensus is to censor the honest party for more than one challenge period, and the costs of engaging in the dispute are minimal.
 
-We've published our initial research [here](https://arxiv.org/abs/2411.05463), and committed it [here](docs/dave.pdf) for convenience.
+We've published our initial research [here](https://arxiv.org/abs/2411.05463), and committed it to [here](docs/dave.pdf) for convenience.


### PR DESCRIPTION
**Description**:  
I noticed a small grammatical issue in the documentation. The phrase "committed it" should be corrected to "**committed it to**" in the sentence:  
> "We've published our initial research [[here](https://arxiv.org/abs/2411.05463)](https://arxiv.org/abs/2411.05463), and committed it [[here](https://chatgpt.com/c/docs/dave.pdf)](docs/dave.pdf) for convenience."

The correction is important for clarity and readability, as the proper preposition "to" is necessary to correctly express the action of committing a resource or document. This minor fix ensures the sentence follows standard English grammar and makes the meaning clearer for all readers.