### PR TITLE
feat: set `via_ir` to `true`

### DIFF
--- a/prt/contracts/foundry.toml
+++ b/prt/contracts/foundry.toml
@@ -2,6 +2,7 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+via_ir = true
 
 allow_paths = ['../../machine/step/']
 remappings = [

--- a/prt/contracts/test/Clock.t.sol
+++ b/prt/contracts/test/Clock.t.sol
@@ -62,10 +62,10 @@ contract ClockTest is Test {
         clock1.advanceClock();
         assertTrue(clock1.hasTimeLeft(), "clock1 should have time left");
 
-        vm.warp(block.timestamp + clock1Allowance - 1);
+        vm.warp(vm.getBlockTimestamp() + clock1Allowance - 1);
         assertTrue(clock1.hasTimeLeft(), "clock1 should have time left");
 
-        vm.warp(block.timestamp + clock1Allowance);
+        vm.warp(vm.getBlockTimestamp() + clock1Allowance);
         assertTrue(!clock1.hasTimeLeft(), "clock1 should run out of time");
 
         vm.expectRevert("can't advance clock with no time left");

--- a/prt/contracts/test/MultiTournament.t.sol
+++ b/prt/contracts/test/MultiTournament.t.sol
@@ -55,7 +55,7 @@ contract MultiTournamentTest is Util, Test {
         );
 
         // player 0 should win after fast forward time to tournament finishes
-        uint256 _t = block.timestamp;
+        uint256 _t = vm.getBlockTimestamp();
         uint256 _tournamentFinish =
             _t + Time.Duration.unwrap(ArbitrationConstants.MAX_ALLOWANCE);
 
@@ -298,7 +298,7 @@ contract MultiTournamentTest is Util, Test {
         assertFalse(_finished, "winner should be zero node");
 
         // player 0 should win after fast forward time to inner tournament finishes
-        uint256 _t = block.timestamp;
+        uint256 _t = vm.getBlockTimestamp();
         // the delay is increased when a match is created
         uint256 _rootTournamentFinish = _t
             + Time.Duration.unwrap(ArbitrationConstants.MAX_ALLOWANCE)
@@ -370,7 +370,7 @@ contract MultiTournamentTest is Util, Test {
         (_finished, _winner,) = middleTournament.innerTournamentWinner();
         assertTrue(_winner.isZero(), "winner should be zero node");
 
-        _t = block.timestamp;
+        _t = vm.getBlockTimestamp();
         // the delay is increased when a match is created
         _rootTournamentFinish =
             _t + Time.Duration.unwrap(ArbitrationConstants.MAX_ALLOWANCE);
@@ -450,7 +450,7 @@ contract MultiTournamentTest is Util, Test {
             topTournament.getMatch(_matchId.hashFromId());
         assertTrue(_match.exists(), "match should exist");
 
-        uint256 _t = block.timestamp;
+        uint256 _t = vm.getBlockTimestamp();
         // the delay is increased when a match is created
         uint256 _rootTournamentFinish =
             _t + 2 * Time.Duration.unwrap(ArbitrationConstants.MAX_ALLOWANCE);

--- a/prt/contracts/test/Tournament.t.sol
+++ b/prt/contracts/test/Tournament.t.sol
@@ -61,7 +61,7 @@ contract TournamentTest is Util, Test {
     function testTimeout() public {
         topTournament = Util.initializePlayer0Tournament(factory);
 
-        uint256 _t = block.timestamp;
+        uint256 _t = vm.getBlockTimestamp();
         // the delay is increased when a match is created
         uint256 _tournamentFinishWithMatch = _t
             + Time.Duration.unwrap(ArbitrationConstants.MAX_ALLOWANCE)
@@ -114,7 +114,7 @@ contract TournamentTest is Util, Test {
         );
 
         topTournament = Util.initializePlayer0Tournament(factory);
-        _t = block.timestamp;
+        _t = vm.getBlockTimestamp();
 
         // the delay is increased when a match is created
         _tournamentFinishWithMatch = _t


### PR DESCRIPTION
## Gas report diff

| Contract | Function | Min | Avg | Max |
| :- | :- | :-: | :-: | :-: |
| BottomTournament | advanceMatch | -518 (-0.79%) | -518 (-0.78%) | -518 (-0.78%) |
| BottomTournament | getMatch | 136 (9.16%) | 136 (9.16%) | 136 (9.16%) |
| BottomTournament | getMatchCycle | 77 (4.34%) | 77 (4.34%) | 77 (4.34%) |
| BottomTournament | joinTournament | 2586 (2.28%) | 2611 (1.58%) | 2636 (1.22%) |
| BottomTournament | sealLeafMatch | -239 (-0.33%) | -239 (-0.33%) | -239 (-0.33%) |
| BottomTournament | winLeafMatch | 703 (0.79%) | 703 (0.79%) | 703 (0.79%) |
| MiddleTournament | advanceMatch | -685 (-1.04%) | -685 (-1.03%) | -685 (-1.03%) |
| MiddleTournament | getCommitment | 24 (2.58%) | 24 (1.06%) | 24 (0.82%) |
| MiddleTournament | getMatch | 124 (8.36%) | 124 (8.36%) | 124 (8.36%) |
| MiddleTournament | getMatchCycle | -35 (-1.86%) | -35 (-1.86%) | -35 (-1.86%) |
| MiddleTournament | innerTournamentWinner | -276 (-35.94%) | -269 (-7.82%) | -254 (-3.48%) |
| MiddleTournament | joinTournament | 397 (0.38%) | 356 (0.24%) | 294 (0.14%) |
| MiddleTournament | sealInnerMatchAndCreateInnerTournament | -717999 (-15.65%) | -717999 (-15.65%) | -717999 (-15.65%) |
| MiddleTournament | winMatchByTimeout | -166 (-0.40%) | -260 (-0.48%) | -354 (-0.53%) |
| MultiLevelTournamentFactory | | | | -29423 (-9.56%) |
| MultiLevelTournamentFactory | instantiateTop | -776210 (-30.91%) | -776210 (-30.91%) | -776210 (-30.91%) |
| SingleLevelTournament | tournamentLevelConstants | 214 (29.44%) | 214 (29.44%) | 214 (29.44%) |
| SingleLevelTournamentFactory | | | | -807158 (-16.27%) |
| SingleLevelTournamentFactory | instantiateSingleLevel | -713577 (-16.10%) | -713577 (-16.10%) | -713577 (-16.10%) |
| TopTournament | advanceMatch | -685 (-1.04%) | -700 (-1.04%) | -764 (-0.88%) |
| TopTournament | arbitrationResult | -154 (-19.79%) | -155 (-10.95%) | -159 (-4.89%) |
| TopTournament | canWinMatchByTimeout | -100 (-7.86%) | -92 (-6.89%) | -88 (-6.44%) |
| TopTournament | eliminateMatchByTimeout | -146 (-0.34%) | -261 (-0.58%) | -376 (-0.80%) |
| TopTournament | getCommitment | 24 (2.65%) | 24 (2.65%) | 24 (2.65%) |
| TopTournament | getMatch | 124 (8.36%) | 124 (8.36%) | 124 (8.36%) |
| TopTournament | getMatchCycle | -35 (-1.88%) | -35 (-1.88%) | -35 (-1.88%) |
| TopTournament | joinTournament | 1414 (2.82%) | 1223 (0.76%) | 1161 (0.54%) |
| TopTournament | sealInnerMatchAndCreateInnerTournament | -783551 (-29.45%) | -783615 (-29.42%) | -783874 (-29.31%) |
| TopTournament | tournamentLevelConstants | 202 (28.65%) | 202 (28.65%) | 202 (28.65%) |
| TopTournament | winInnerMatch | -575 (-0.76%) | -565 (-0.75%) | -555 (-0.74%) |
| TopTournament | winMatchByTimeout | -371 (-0.56%) | -362 (-0.54%) | -354 (-0.53%) |

_(generated by [`guidanoli/gas-report-parser`](https://github.com/guidanoli/gas-report-parser))_