### PR TITLE
refactor: simplify `IDataProvider`

### DIFF
--- a/prt/contracts/src/IDataProvider.sol
+++ b/prt/contracts/src/IDataProvider.sol
@@ -4,14 +4,12 @@
 pragma solidity ^0.8.17;
 
 interface IDataProvider {
-    /// @notice Provides the Merkle root of the response to a Generic I/O request
-    /// @param namespace The request namespace
-    /// @param id The request ID
-    /// @param extra Extra data (e.g. proofs)
-    /// @return Merkle root of response
-    /// @return Size of the response (in bytes)
-    function gio(uint16 namespace, bytes calldata id, bytes calldata extra)
-        external
-        view
-        returns (bytes32, uint256);
+    /// @notice Provides the Merkle root of an input
+    /// @param inputIndexWithinEpoch The index of the input within the epoch
+    /// @param input The input blob (to hash and check against the input box)
+    /// @return The root of smallest Merkle tree that fits the input
+    function provideMerkleRootOfInput(
+        uint256 inputIndexWithinEpoch,
+        bytes calldata input
+    ) external view returns (bytes32);
 }

--- a/prt/contracts/src/tournament/abstracts/LeafTournament.sol
+++ b/prt/contracts/src/tournament/abstracts/LeafTournament.sol
@@ -151,17 +151,17 @@ abstract contract LeafTournament is Tournament {
 
                 if (inputLength > 0) {
                     bytes calldata input = proofs[32:32 + inputLength];
-                    uint256 inputIndex = counter
+                    uint256 inputIndexWithinEpoch = counter
                         >> (
                             ArbitrationConstants.LOG2_EMULATOR_SPAN
                                 + ArbitrationConstants.LOG2_UARCH_SPAN
-                        ); // TODO: add input index offset of the epoch
+                        );
 
                     // TODO: maybe assert retrieved input length matches?
-                    (bytes32 inputMerkleRoot, uint256 retrievedInputLength) =
-                        provider.gio(0, abi.encode(inputIndex), input);
+                    bytes32 inputMerkleRoot = provider.provideMerkleRootOfInput(
+                        inputIndexWithinEpoch, input
+                    );
 
-                    require(inputLength == retrievedInputLength);
                     require(inputMerkleRoot != bytes32(0));
                     SendCmioResponse.sendCmioResponse(
                         accessLogs,


### PR DESCRIPTION
- The `IDataProvider` implementation should be aware of epoch boundaries, and receive input indices relative to the epoch, to facilitate usage by tournament contracts
- `namespace` is not necessary because, as of now, it's just a constant
- `extra` is always `input` in the current stage
- Block numbers are not necessary, because input indices delimit epoch boundaries already
- Without thinking in terms of block numbers, we don't need to decode input blobs