### PR TITLE
Add an entrypoint for deploying the `MultiLevelTournamentFactory` contract

### DIFF
--- a/prt/contracts/deploy_anvil.sh
+++ b/prt/contracts/deploy_anvil.sh
@@ -7,7 +7,7 @@ INITIAL_HASH=`xxd -p -c32 "${MACHINE_PATH}/hash"`
 export PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 forge_script="forge script \
-    script/TopTournament.s.sol \
+    script/Deploy.s.sol \
     --fork-url 'http://127.0.0.1:8545' \
     --broadcast \
     --sig 'run(bytes32)' \

--- a/prt/contracts/deploy_anvil.sh
+++ b/prt/contracts/deploy_anvil.sh
@@ -10,7 +10,7 @@ forge_script="forge script \
     script/Deploy.s.sol \
     --fork-url 'http://127.0.0.1:8545' \
     --broadcast \
-    --sig 'run(bytes32)' \
+    --sig 'deployTopTournament(bytes32)' \
     '${INITIAL_HASH}' \
     -vvvv 2>&1"
 

--- a/prt/contracts/script/Deploy.s.sol
+++ b/prt/contracts/script/Deploy.s.sol
@@ -18,7 +18,7 @@ contract DeployScript is Script {
         vm.stopBroadcast();
     }
 
-    function run(Machine.Hash initialHash) external broadcast {
+    function deployTopTournament(Machine.Hash initialHash) external broadcast {
         MultiLevelTournamentFactory factory = _deployFactory();
         factory.instantiate(initialHash, IDataProvider(address(0x0)));
     }

--- a/prt/contracts/script/Deploy.s.sol
+++ b/prt/contracts/script/Deploy.s.sol
@@ -23,6 +23,10 @@ contract DeployScript is Script {
         factory.instantiate(initialHash, IDataProvider(address(0x0)));
     }
 
+    function deployMultiLevelTournamentFactory() external broadcast {
+        _deployFactory();
+    }
+
     function _deployFactory() internal returns (MultiLevelTournamentFactory) {
         return new MultiLevelTournamentFactory(
             new TopTournamentFactory(),

--- a/prt/contracts/script/Deploy.s.sol
+++ b/prt/contracts/script/Deploy.s.sol
@@ -11,7 +11,7 @@ import "src/tournament/factories/MultiLevelTournamentFactory.sol";
 import "src/IDataProvider.sol";
 import "src/CanonicalConstants.sol";
 
-contract TopTournamentScript is Script {
+contract DeployScript is Script {
     modifier broadcast() {
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
         _;

--- a/prt/contracts/script/TopTournament.s.sol
+++ b/prt/contracts/script/TopTournament.s.sol
@@ -13,30 +13,13 @@ import "src/CanonicalConstants.sol";
 
 contract TopTournamentScript is Script {
     function run(Machine.Hash initialHash) external {
-        DisputeParameters memory disputeParameters = DisputeParameters({
-            timeConstants: TimeConstants({
-                matchEffort: ArbitrationConstants.MATCH_EFFORT,
-                maxAllowance: ArbitrationConstants.MAX_ALLOWANCE
-            }),
-            commitmentStructures: new CommitmentStructure[](
-                ArbitrationConstants.LEVELS
-            )
-        });
-
-        for (uint64 i; i < ArbitrationConstants.LEVELS; ++i) {
-            disputeParameters.commitmentStructures[i] = CommitmentStructure({
-                log2step: ArbitrationConstants.log2step(i),
-                height: ArbitrationConstants.height(i)
-            });
-        }
-
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
 
         MultiLevelTournamentFactory factory = new MultiLevelTournamentFactory(
             new TopTournamentFactory(),
             new MiddleTournamentFactory(),
             new BottomTournamentFactory(),
-            disputeParameters
+            ArbitrationConstants.disputeParameters()
         );
 
         factory.instantiate(initialHash, IDataProvider(address(0x0)));

--- a/prt/contracts/script/TopTournament.s.sol
+++ b/prt/contracts/script/TopTournament.s.sol
@@ -15,15 +15,19 @@ contract TopTournamentScript is Script {
     function run(Machine.Hash initialHash) external {
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
 
-        MultiLevelTournamentFactory factory = new MultiLevelTournamentFactory(
+        MultiLevelTournamentFactory factory = _deployFactory();
+
+        factory.instantiate(initialHash, IDataProvider(address(0x0)));
+
+        vm.stopBroadcast();
+    }
+
+    function _deployFactory() internal returns (MultiLevelTournamentFactory) {
+        return new MultiLevelTournamentFactory(
             new TopTournamentFactory(),
             new MiddleTournamentFactory(),
             new BottomTournamentFactory(),
             ArbitrationConstants.disputeParameters()
         );
-
-        factory.instantiate(initialHash, IDataProvider(address(0x0)));
-
-        vm.stopBroadcast();
     }
 }

--- a/prt/contracts/script/TopTournament.s.sol
+++ b/prt/contracts/script/TopTournament.s.sol
@@ -12,14 +12,15 @@ import "src/IDataProvider.sol";
 import "src/CanonicalConstants.sol";
 
 contract TopTournamentScript is Script {
-    function run(Machine.Hash initialHash) external {
+    modifier broadcast() {
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
-
-        MultiLevelTournamentFactory factory = _deployFactory();
-
-        factory.instantiate(initialHash, IDataProvider(address(0x0)));
-
+        _;
         vm.stopBroadcast();
+    }
+
+    function run(Machine.Hash initialHash) external broadcast {
+        MultiLevelTournamentFactory factory = _deployFactory();
+        factory.instantiate(initialHash, IDataProvider(address(0x0)));
     }
 
     function _deployFactory() internal returns (MultiLevelTournamentFactory) {

--- a/prt/contracts/src/CanonicalConstants.sol
+++ b/prt/contracts/src/CanonicalConstants.sol
@@ -4,6 +4,7 @@
 pragma solidity ^0.8.17;
 
 import "./tournament/libs/Time.sol";
+import "./DisputeParameters.sol";
 
 library ArbitrationConstants {
     // maximum time for computing the commitments offchain
@@ -43,5 +44,45 @@ library ArbitrationConstants {
     function height(uint64 level) internal pure returns (uint64) {
         uint64[LEVELS] memory arr = [uint64(48), uint64(16), uint64(28)];
         return arr[level];
+    }
+
+    function disputeParameters()
+        internal
+        pure
+        returns (DisputeParameters memory)
+    {
+        return DisputeParameters({
+            timeConstants: timeConstants(),
+            commitmentStructures: commitmentStructures()
+        });
+    }
+
+    function timeConstants() internal pure returns (TimeConstants memory) {
+        return TimeConstants({
+            matchEffort: MATCH_EFFORT,
+            maxAllowance: MAX_ALLOWANCE
+        });
+    }
+
+    function commitmentStructures()
+        internal
+        pure
+        returns (CommitmentStructure[] memory structures)
+    {
+        structures = new CommitmentStructure[](LEVELS);
+        for (uint64 level; level < LEVELS; ++level) {
+            structures[level] = commitmentStructure(level);
+        }
+    }
+
+    function commitmentStructure(uint64 level)
+        internal
+        pure
+        returns (CommitmentStructure memory)
+    {
+        return CommitmentStructure({
+            log2step: log2step(level),
+            height: height(level)
+        });
     }
 }

--- a/prt/contracts/src/DisputeParameters.sol
+++ b/prt/contracts/src/DisputeParameters.sol
@@ -1,0 +1,21 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+pragma solidity ^0.8.17;
+
+import "./tournament/libs/Time.sol";
+
+struct CommitmentStructure {
+    uint64 log2step;
+    uint64 height;
+}
+
+struct TimeConstants {
+    Time.Duration matchEffort;
+    Time.Duration maxAllowance;
+}
+
+struct DisputeParameters {
+    TimeConstants timeConstants;
+    CommitmentStructure[] commitmentStructures;
+}

--- a/prt/contracts/src/tournament/factories/MultiLevelTournamentFactory.sol
+++ b/prt/contracts/src/tournament/factories/MultiLevelTournamentFactory.sol
@@ -3,27 +3,13 @@
 
 pragma solidity ^0.8.17;
 
+import "../../DisputeParameters.sol";
 import "../../IMultiLevelTournamentFactory.sol";
 import "../../TournamentParameters.sol";
 
 import "./multilevel/TopTournamentFactory.sol";
 import "./multilevel/MiddleTournamentFactory.sol";
 import "./multilevel/BottomTournamentFactory.sol";
-
-struct CommitmentStructure {
-    uint64 log2step;
-    uint64 height;
-}
-
-struct TimeConstants {
-    Time.Duration matchEffort;
-    Time.Duration maxAllowance;
-}
-
-struct DisputeParameters {
-    TimeConstants timeConstants;
-    CommitmentStructure[] commitmentStructures;
-}
 
 contract MultiLevelTournamentFactory is IMultiLevelTournamentFactory {
     TopTournamentFactory immutable topFactory;


### PR DESCRIPTION
This PR is composed of several small commits for better readability.
Later, we can squash them all into one commit to avoid polluting the upstream commit history.