### PR TITLE
ci: use Foundry stable release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
 
       - name: Install just
         uses: extractions/setup-just@v2


### PR DESCRIPTION
Running `cargo test` locally with stable release of Foundry works fine.
On the CI, it takes hours for some reason.