### PR TITLE
fix: run forge script non-interactively

### DIFF
--- a/cartesi-rollups/contracts/deploy_anvil.sh
+++ b/cartesi-rollups/contracts/deploy_anvil.sh
@@ -10,6 +10,7 @@ inputbox_script="forge script \
     script/InputBox.s.sol \
     --fork-url 'http://127.0.0.1:8545' \
     --broadcast \
+    --non-interactive \
     --sig 'run()' \
     -vvvv 2>&1"
 
@@ -22,6 +23,7 @@ daveconsensus_script="forge script \
     script/DaveConsensus.s.sol \
     --fork-url 'http://127.0.0.1:8545' \
     --broadcast \
+    --non-interactive \
     --sig 'run(bytes32,address)' \
     '$INITIAL_HASH' \
     '$INPUTBOX_ADDRESS' \

--- a/cartesi-rollups/contracts/justfile
+++ b/cartesi-rollups/contracts/justfile
@@ -37,6 +37,7 @@ deploy-dev INITIAL_HASH:
         script/InputBox.s.sol \
         --fork-url {{ANVIL_ENDPOINT}} \
         --broadcast \
+        --non-interactive \
         --sig 'run()' \
         -vvvv 2>&1
     forge script \
@@ -44,6 +45,7 @@ deploy-dev INITIAL_HASH:
         --fork-url {{ANVIL_ENDPOINT}} \
         --code-size-limit 65536 \
         --broadcast \
+        --non-interactive \
         --sig 'run(bytes32,address)' \
         {{INITIAL_HASH}} \
         $(jq -r '.transactions[] | select(.transactionType=="CREATE").contractAddress' broadcast/InputBox.s.sol/{{ANVIL_CHAIN_ID}}/run-latest.json) \

--- a/prt/contracts/deploy_anvil.sh
+++ b/prt/contracts/deploy_anvil.sh
@@ -10,6 +10,7 @@ forge_script="forge script \
     script/TopTournament.s.sol \
     --fork-url 'http://127.0.0.1:8545' \
     --broadcast \
+    --non-interactive \
     --sig 'run(bytes32)' \
     '${INITIAL_HASH}' \
     -vvvv 2>&1"


### PR DESCRIPTION
The `--non-interactive` option makes `forge script` respond "yes" by default to a confirmation question of whether the user would like to deploy a contract even though it is greater than the size limit. With this option, we could even remove the `--code-size-limit 65536` option from `cartesi-rollups/contracts/justfile`.