### PR TITLE
Load contract addresses from deployment file

### DIFF
--- a/cartesi-rollups/contracts/script/DaveConsensus.s.sol
+++ b/cartesi-rollups/contracts/script/DaveConsensus.s.sol
@@ -12,7 +12,7 @@ import "prt-contracts/CanonicalTournamentParametersProvider.sol";
 import "rollups-contracts/inputs/IInputBox.sol";
 import "src/DaveConsensus.sol";
 
-contract DaveConcensusScript is Script {
+contract DaveConsensusScript is Script {
     function run(Machine.Hash initialHash, IInputBox inputBox) external {
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
 

--- a/prt/tests/rollups/dave/node.lua
+++ b/prt/tests/rollups/dave/node.lua
@@ -1,12 +1,13 @@
 local helper = require "utils.helper"
 
-local function start_dave_node(machine_path, db_path, sleep_duration, verbosity, trace_level)
+local function start_dave_node(machine_path, db_path, consensus, input_box, sleep_duration, verbosity, trace_level)
     local cmd = string.format(
         [[sh -c "echo $$ ; exec env MACHINE_PATH='%s' STATE_DIR='%s' \
+        CONSENSUS='%s' INPUT_BOX='%s' \
         SLEEP_DURATION=%d RUST_BACKTRACE='%s' \
         RUST_LOG='none',cartesi_prt_core='%s',rollups_prt_runner='%s',rollups_epoch_manager='%s' \
         ../../../target/debug/dave-rollups > dave.log 2>&1"]],
-        machine_path, db_path, sleep_duration, trace_level, verbosity, verbosity, verbosity
+        machine_path, db_path, consensus, input_box, sleep_duration, trace_level, verbosity, verbosity, verbosity
     )
 
     local reader = io.popen(cmd)
@@ -28,11 +29,11 @@ end
 local Dave = {}
 Dave.__index = Dave
 
-function Dave:new(machine_path, sleep_duration, verbosity, trace_level)
+function Dave:new(machine_path, consensus, input_box, sleep_duration, verbosity, trace_level)
     local n = {}
     os.execute "rm -rf _state && mkdir _state"
 
-    local handle = start_dave_node(machine_path, "_state/", sleep_duration, verbosity, trace_level)
+    local handle = start_dave_node(machine_path, "_state/", consensus, input_box, sleep_duration, verbosity, trace_level)
 
     n._handle = handle
 

--- a/prt/tests/rollups/justfile
+++ b/prt/tests/rollups/justfile
@@ -1,10 +1,18 @@
+ECHO_DIR := "../../../test/programs/echo"
+
+INPUT_BOX := `head -n 1 ../../../test/programs/echo/addresses`
+CONSENSUS := `head -n 2 ../../../test/programs/echo/addresses | tail -n 1`
+
 # run PRT rollups test
 test MACH_PATH:
   rm -rf _state
+  CONSENSUS={{CONSENSUS}} \
+  INPUT_BOX={{INPUT_BOX}} \
   MACHINE_PATH={{MACH_PATH}} lua prt_rollups.lua
 
 # run PRT rollups echo test
-test-echo: (test "../../../test/programs/echo")
+test-echo: 
+  just test {{ECHO_DIR}}
 
 # read logs from PRT Rollups node, run in separate terminal after `test-echo`
 read-node-logs:

--- a/prt/tests/rollups/prt_rollups.lua
+++ b/prt/tests/rollups/prt_rollups.lua
@@ -1,11 +1,9 @@
 require "setup_path"
 
-
--- TODO load from deployment file `addresses`
 -- consensus contract address in anvil deployment
-local CONSENSUS_ADDRESS = "0x0165878a594ca255338adfa4d48449f69242eb8f"
+local CONSENSUS_ADDRESS = os.getenv("CONSENSUS") or "0x0165878A594ca255338adfa4d48449f69242Eb8F"
 -- input contract address in anvil deployment
-local INPUT_BOX_ADDRESS = "0x5FbDB2315678afecb367f032d93F642f64180aa3";
+local INPUT_BOX_ADDRESS = os.getenv("INPUT_BOX") or "0x5FbDB2315678afecb367f032d93F642f64180aa3";
 
 -- amount of time sleep between each react
 local SLEEP_TIME = 2
@@ -187,7 +185,8 @@ time.sleep(NODE_DELAY)
 local verbosity = os.getenv("VERBOSITY") or 'debug'
 -- 0, 1, full
 local trace_level = os.getenv("TRACE_LEVEL") or 'full'
-local dave_node = Dave:new(rollups_machine_path .. "/machine-image", SLEEP_TIME, verbosity, trace_level)
+local dave_node = Dave:new(rollups_machine_path .. "/machine-image", CONSENSUS_ADDRESS, INPUT_BOX_ADDRESS, SLEEP_TIME,
+    verbosity, trace_level)
 time.sleep(NODE_DELAY)
 
 local reader = Reader:new(blockchain_constants.endpoint)


### PR DESCRIPTION
Since we've done a couple big and small refactorings on the smart contracts. Their deployment order and addresses change from time to time. It becomes annoying to change the "default address" which we thought shouldn't change a lot. Hence I try to extract the smart contract addresses from `addresses` file that produced by our anvil script.