### PR TITLE
fix:(client-lua): update lua bindings

### DIFF
--- a/prt/client-lua/computation/machine.lua
+++ b/prt/client-lua/computation/machine.lua
@@ -22,9 +22,9 @@ function ComputationState.from_current_machine_state(machine)
     local hash = Hash:from_digest(machine:get_root_hash())
     return ComputationState:new(
         hash,
-        machine:read_reg("iflags_H"),
-        machine:read_reg("iflags_Y"),
-        machine:read_reg("uarch_halt_flag")
+        machine:read_reg("iflags_H") ~= 0,
+        machine:read_reg("iflags_Y") ~= 0,
+        machine:read_reg("uarch_halt_flag") ~= 0
     )
 end
 
@@ -122,9 +122,11 @@ end
 
 function Machine:take_snapshot(snapshot_dir, cycle, handle_rollups)
     local input_mask = arithmetic.max_uint(consts.log2_emulator_span)
-    if handle_rollups and cycle & input_mask == 0 then
-        -- dont snapshot a machine state that's freshly fed with input without advance
-        assert(not self.yielded, "don't snapshot a machine state that's freshly fed with input without advance")
+    if handle_rollups and ((cycle & input_mask) == 0) then
+        if (not self.yielded) then
+            -- don't snapshot a machine state that's freshly fed with input without advance
+            return
+        end
     end
 
     if helper.exists(snapshot_dir) then
@@ -168,7 +170,21 @@ function Machine:run(cycle)
     local mcycle = machine:read_reg("mcycle")
     local physical_cycle = add_and_clamp(mcycle, cycle - self.cycle) -- TODO reconsider for lambda
 
-    while not (machine:read_reg("iflags_H") or machine:read_reg("iflags_Y") or machine:read_reg("mcycle") == physical_cycle) do
+    while true do
+        if machine:read_reg("iflags_H") ~= 0 then
+            -- print("break with halt")
+            break
+        end
+
+        if machine:read_reg("iflags_Y") ~= 0 then
+            -- print("break with yield")
+            break
+        end
+
+        if machine:read_reg("mcycle") == physical_cycle then
+            -- print("break with with meeting physical cycle")
+        end
+
         machine:run(physical_cycle)
     end
 
@@ -302,7 +318,6 @@ function Machine.get_logs(path, snapshot_dir, cycle, ucycle, inputs)
     local machine = Machine:new_from_path(path)
     machine:load_snapshot(snapshot_dir, cycle)
     local logs = {}
-    local log_type = { annotations = true, proofs = true }
     local encode_input = nil
     if inputs then
         -- treat it as rollups
@@ -330,12 +345,13 @@ function Machine.get_logs(path, snapshot_dir, cycle, ucycle, inputs)
                     table.insert(logs,
                         machine.machine:log_send_cmio_response(cartesi.CMIO_YIELD_REASON_ADVANCE_STATE,
                             data_hex,
-                            log_type
+                            cartesi.ACCESS_LOG_TYPE_LARGE_DATA
                         ))
-                    table.insert(logs, machine.machine:log_uarch_step(log_type))
+                    table.insert(logs, machine.machine:log_step_uarch(cartesi.ACCESS_LOG_TYPE_LARGE_DATA))
                     return encode_access_logs(logs, input)
                 else
-                    machine.machine:send_cmio_response(cartesi.CMIO_YIELD_REASON_ADVANCE_STATE, data_hex)
+                    machine.machine:send_cmio_response(cartesi.CMIO_YIELD_REASON_ADVANCE_STATE, data_hex,
+                        cartesi.ACCESS_LOG_TYPE_LARGE_DATA)
                 end
             else
                 if ucycle == 0 then
@@ -350,9 +366,9 @@ function Machine.get_logs(path, snapshot_dir, cycle, ucycle, inputs)
 
     machine:run_uarch(ucycle)
     if ucycle == consts.uarch_span then
-        table.insert(logs, machine.machine:log_uarch_reset(log_type))
+        table.insert(logs, machine.machine:log_reset_uarch(cartesi.ACCESS_LOG_TYPE_ANNOTATIONS))
     else
-        table.insert(logs, machine.machine:log_uarch_step(log_type))
+        table.insert(logs, machine.machine:log_step_uarch(cartesi.ACCESS_LOG_TYPE_LARGE_DATA))
     end
     return encode_access_logs(logs, encode_input)
 end

--- a/prt/client-rs/core/src/machine/instance.rs
+++ b/prt/client-rs/core/src/machine/instance.rs
@@ -66,12 +66,11 @@ impl MachineInstance {
     }
     pub fn take_snapshot(&mut self, base_cycle: u64, db: &ComputeStateAccess) -> Result<()> {
         let mask = arithmetic::max_uint(constants::LOG2_EMULATOR_SPAN);
-        if db.handle_rollups && base_cycle & mask == 0 {
-            // don't snapshot a machine state that's freshly fed with input without advance
-            assert!(
-                self.machine_state()?.yielded,
-                "don't snapshot a machine state that's freshly fed with input without advance",
-            );
+        if db.handle_rollups && ((base_cycle & mask) == 0) {
+            if !self.machine_state()?.yielded {
+                // don't snapshot a machine state that's freshly fed with input without advance
+                return Ok(());
+            }
         }
 
         let snapshot_path = db.work_path.join(format!("{}", base_cycle));

--- a/prt/tests/common/runners/hero_runner.lua
+++ b/prt/tests/common/runners/hero_runner.lua
@@ -15,7 +15,7 @@ local function hero_runner(player_id, machine_path, root_commitment, root_tourna
         hook = false
     end
 
-    local snapshot_dir = string.format("/compute_data/%s", root_tournament)
+    local snapshot_dir = string.format("./_state/compute_path/%s", root_tournament)
     local strategy = HonestStrategy:new(
         CommitmentBuilder:new(machine_path, snapshot_dir, root_commitment),
         inputs,

--- a/prt/tests/common/runners/sybil_runner.lua
+++ b/prt/tests/common/runners/sybil_runner.lua
@@ -37,7 +37,7 @@ end
 
 
 local function sybil_runner(player_id, machine_path, root_commitment, root_tournament, fake_commitment_count, inputs)
-    local snapshot_dir = string.format("/compute_data/%s", root_tournament)
+    local snapshot_dir = string.format("./_state/compute_path/%s", root_tournament)
     local strategy = HonestStrategy:new(
         FakeCommitmentBuilder:new(machine_path, root_commitment, snapshot_dir),
         inputs,

--- a/prt/tests/compute/prt_compute.lua
+++ b/prt/tests/compute/prt_compute.lua
@@ -62,7 +62,7 @@ local function setup_players(use_lua_node, extra_data, root_tournament, machine_
     local player_coroutines = {}
     local player_index = 1
     print("Calculating root commitment...")
-    local snapshot_dir = string.format("/compute_data/%s", root_tournament)
+    local snapshot_dir = string.format("./_state/compute_path/%s", root_tournament)
     local builder = CommitmentBuilder:new(machine_path, snapshot_dir)
     local root_commitment = builder:build(0, 0, root_constants.log2_step, root_constants.height, inputs)
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker.io/docker/dockerfile-upstream:1.12.1-labs
 
 # start from rust
-FROM rust:1.83
+FROM rust:1.85
 
 # install `just`
 RUN \
@@ -24,10 +24,11 @@ RUN \
 ENV DEBIAN_FRONTEND=noninteractive
 RUN \
   apt-get update && apt-get install -y --no-install-recommends \
-    build-essential git wget \
-    liblua5.4-dev lua5.4 \
-    libclang-dev \
-    xxd jq sqlite3; \
+  build-essential git wget \
+  liblua5.4-dev lua5.4 \
+  libclang-dev \
+  libslirp-dev \
+  xxd jq sqlite3; \
   rm -rf /var/cache/apt;
 
 WORKDIR /dave


### PR DESCRIPTION
@GCdePaula I think the main issue is how the machine flags were read in the lua code. Now I'm able to run rollups tests (both echo and honeypot) to the leaf tournament and have the honest node win.

Although I think the input payload we used for echo dapp makes zero sense to honeypot. So I always see `[dapp] invalid advance state request`.