### PR TITLE
Improve PRT contracts test coverage part 2

### DIFF
--- a/prt/contracts/test/BottomTournament.t.sol
+++ b/prt/contracts/test/BottomTournament.t.sol
@@ -384,8 +384,28 @@ contract BottomTournamentTest is Util, Test {
             "agree cycle should be zero"
         );
 
+        // mock the IDataProvider to return no valid input
+        vm.mockCall(
+            address(0x12345678901234567890),
+            abi.encode(IDataProvider.provideMerkleRootOfInput.selector),
+            abi.encode(uint256(0))
+        );
+
+        vm.expectRevert("no valid input");
+        // win match, expect revert from no valid input
+        Util.winLeafMatchRollupsWithInput(
+            bottomTournament, _matchId, _playerToSeal
+        );
+
+        // mock the IDataProvider to return valid input
+        vm.mockCall(
+            address(0x12345678901234567890),
+            abi.encode(IDataProvider.provideMerkleRootOfInput.selector),
+            abi.encode(uint256(999))
+        );
+
         vm.expectRevert();
-        // win match, expect revert
+        // win match, expect revert from the cmio function
         Util.winLeafMatchRollupsWithInput(
             bottomTournament, _matchId, _playerToSeal
         );

--- a/prt/contracts/test/BottomTournament.t.sol
+++ b/prt/contracts/test/BottomTournament.t.sol
@@ -26,19 +26,22 @@ contract BottomTournamentTest is Util, Test {
     using Machine for Machine.Hash;
 
     MultiLevelTournamentFactory immutable factory;
+    StateTransition immutable stateTransition;
     TopTournament topTournament;
     MiddleTournament middleTournament;
     BottomTournament bottomTournament;
 
+    error WrongNodesForStep();
+
     event newInnerTournament(Match.IdHash indexed, NonRootTournament);
 
     constructor() {
-        factory = Util.instantiateTournamentFactory();
+        (factory, stateTransition) = Util.instantiateTournamentFactory();
     }
 
     function setUp() public {}
 
-    function testComputeStep() public {
+    function testCommitmentOneWon() public {
         topTournament = Util.initializePlayer0Tournament(factory);
 
         // pair commitment, expect a match
@@ -143,12 +146,16 @@ contract BottomTournamentTest is Util, Test {
             "agree cycle should be zero"
         );
 
-        vm.expectRevert();
-        // win match, expect revert
+        vm.mockCall(
+            address(stateTransition),
+            abi.encode(IStateTransition.transitionState.selector),
+            abi.encode(Machine.Hash.unwrap(Util.ONE_STATE))
+        );
+
         Util.winLeafMatch(bottomTournament, _matchId, _playerToSeal);
     }
 
-    function testComputeReset() public {
+    function testCommitmentTwoWon() public {
         topTournament = Util.initializePlayer0Tournament(factory);
 
         // pair commitment, expect a match
@@ -274,13 +281,16 @@ contract BottomTournamentTest is Util, Test {
             "agree cycle should be 4951760157141521099596496895"
         );
 
-        vm.expectRevert();
-        // win match, expect revert
-        Util.winLeafMatch(bottomTournament, _matchId, _playerToSeal);
+        vm.mockCall(
+            address(stateTransition),
+            abi.encode(IStateTransition.transitionState.selector),
+            abi.encode(Machine.Hash.unwrap(Util.TWO_STATE))
+        );
+        Util.winLeafMatch(bottomTournament, _matchId, 2);
     }
 
-    function testRollupsCmio() public {
-        topTournament = Util.initializePlayer0RollupsTournament(factory);
+    function testWrongNode() public {
+        topTournament = Util.initializePlayer0Tournament(factory);
 
         // pair commitment, expect a match
         // player 1 joins tournament
@@ -384,273 +394,14 @@ contract BottomTournamentTest is Util, Test {
             "agree cycle should be zero"
         );
 
-        // mock the IDataProvider to return no valid input
         vm.mockCall(
-            address(0x12345678901234567890),
-            abi.encode(IDataProvider.provideMerkleRootOfInput.selector),
-            abi.encode(uint256(0))
+            address(stateTransition),
+            abi.encode(IStateTransition.transitionState.selector),
+            abi.encode(Machine.Hash.unwrap(Util.ONE_STATE))
         );
-
-        vm.expectRevert("no valid input");
-        // win match, expect revert from no valid input
-        Util.winLeafMatchRollupsWithInput(
-            bottomTournament, _matchId, _playerToSeal
+        vm.expectRevert(WrongNodesForStep.selector);
+        bottomTournament.winLeafMatch(
+            _matchId, Util.ONE_NODE, Util.ONE_NODE, new bytes(0)
         );
-
-        // mock the IDataProvider to return valid input
-        vm.mockCall(
-            address(0x12345678901234567890),
-            abi.encode(IDataProvider.provideMerkleRootOfInput.selector),
-            abi.encode(uint256(999))
-        );
-
-        vm.expectRevert();
-        // win match, expect revert from the cmio function
-        Util.winLeafMatchRollupsWithInput(
-            bottomTournament, _matchId, _playerToSeal
-        );
-    }
-
-    function testRollupsStep() public {
-        topTournament = Util.initializePlayer0RollupsTournament(factory);
-
-        // pair commitment, expect a match
-        // player 1 joins tournament
-        uint256 _opponent = 1;
-        uint64 _height = 0;
-        Util.joinTournament(topTournament, _opponent);
-
-        Match.Id memory _matchId = Util.matchId(_opponent, _height);
-        Match.State memory _match =
-            topTournament.getMatch(_matchId.hashFromId());
-        assertTrue(_match.exists(), "match should exist");
-
-        // advance match to end, this match will always advance to left tree
-        uint256 _playerToSeal =
-            Util.advanceMatch(topTournament, _matchId, _opponent);
-
-        // expect new inner created
-        vm.recordLogs();
-
-        // seal match
-        Util.sealInnerMatchAndCreateInnerTournament(
-            topTournament, _matchId, _playerToSeal
-        );
-        _height += 1;
-
-        assertEq(
-            topTournament.getMatchCycle(_matchId.hashFromId()),
-            0,
-            "agree cycle should be zero"
-        );
-
-        Vm.Log[] memory _entries = vm.getRecordedLogs();
-        assertEq(_entries[0].topics.length, 2);
-        assertEq(
-            _entries[0].topics[0],
-            keccak256("newInnerTournament(bytes32,address)")
-        );
-        assertEq(
-            _entries[0].topics[1], Match.IdHash.unwrap(_matchId.hashFromId())
-        );
-
-        middleTournament = MiddleTournament(
-            address(bytes20(bytes32(_entries[0].data) << (12 * 8)))
-        );
-
-        Util.joinTournament(middleTournament, 0);
-        Util.joinTournament(middleTournament, _opponent);
-
-        _matchId = Util.matchId(_opponent, _height);
-        _match = middleTournament.getMatch(_matchId.hashFromId());
-        assertTrue(_match.exists(), "match should exist");
-
-        // advance match to end, this match will always advance to left tree
-        _playerToSeal = Util.advanceMatch(middleTournament, _matchId, _opponent);
-
-        // expect new inner created (middle 2)
-        vm.recordLogs();
-
-        // seal match
-        Util.sealInnerMatchAndCreateInnerTournament(
-            middleTournament, _matchId, _playerToSeal
-        );
-        _height += 1;
-
-        assertEq(
-            middleTournament.getMatchCycle(_matchId.hashFromId()),
-            0,
-            "agree cycle should be zero"
-        );
-
-        _entries = vm.getRecordedLogs();
-        assertEq(_entries[0].topics.length, 2);
-        assertEq(
-            _entries[0].topics[0],
-            keccak256("newInnerTournament(bytes32,address)")
-        );
-        assertEq(
-            _entries[0].topics[1], Match.IdHash.unwrap(_matchId.hashFromId())
-        );
-
-        bottomTournament = BottomTournament(
-            address(bytes20(bytes32(_entries[0].data) << (12 * 8)))
-        );
-
-        Util.joinTournament(bottomTournament, 0);
-        Util.joinTournament(bottomTournament, _opponent);
-
-        _matchId = Util.matchId(_opponent, _height);
-        _match = bottomTournament.getMatch(_matchId.hashFromId());
-        assertTrue(_match.exists(), "match should exist");
-
-        // advance match to end, this match will always advance to left tree
-        _playerToSeal = Util.advanceMatch(bottomTournament, _matchId, _opponent);
-
-        // seal match
-        Util.sealLeafMatch(bottomTournament, _matchId, _playerToSeal);
-
-        assertEq(
-            bottomTournament.getMatchCycle(_matchId.hashFromId()),
-            0,
-            "agree cycle should be zero"
-        );
-
-        vm.expectRevert();
-        // win match, expect revert
-        Util.winLeafMatchRollupsWithoutInput(
-            bottomTournament, _matchId, _playerToSeal
-        );
-    }
-
-    function testRollupsReset() public {
-        topTournament = Util.initializePlayer0RollupsTournament(factory);
-
-        // pair commitment, expect a match
-        // player 2 joins tournament
-        uint256 _opponent = 2;
-        uint64 _height = 0;
-        Util.joinTournament(topTournament, _opponent);
-
-        Match.Id memory _matchId = Util.matchId(_opponent, _height);
-        Match.State memory _match =
-            topTournament.getMatch(_matchId.hashFromId());
-        assertTrue(_match.exists(), "match should exist");
-
-        // advance match to end, this match will always advance to right tree
-        uint256 _playerToSeal =
-            Util.advanceMatch(topTournament, _matchId, _opponent);
-
-        // expect new inner created
-        vm.recordLogs();
-
-        // seal match
-        Util.sealInnerMatchAndCreateInnerTournament(
-            topTournament, _matchId, _playerToSeal
-        );
-        _height += 1;
-
-        uint256 cycle = (
-            1
-                << (
-                    ArbitrationConstants.height(0)
-                        + ArbitrationConstants.log2step(0)
-                )
-        ) - (1 << ArbitrationConstants.log2step(0));
-        assertEq(
-            topTournament.getMatchCycle(_matchId.hashFromId()),
-            cycle,
-            "agree cycle should be 4951760157141503507410452480"
-        );
-
-        Vm.Log[] memory _entries = vm.getRecordedLogs();
-        assertEq(_entries[0].topics.length, 2);
-        assertEq(
-            _entries[0].topics[0],
-            keccak256("newInnerTournament(bytes32,address)")
-        );
-        assertEq(
-            _entries[0].topics[1], Match.IdHash.unwrap(_matchId.hashFromId())
-        );
-
-        middleTournament = MiddleTournament(
-            address(bytes20(bytes32(_entries[0].data) << (12 * 8)))
-        );
-
-        Util.joinTournament(middleTournament, 0);
-        Util.joinTournament(middleTournament, _opponent);
-
-        _matchId = Util.matchId(_opponent, _height);
-        _match = middleTournament.getMatch(_matchId.hashFromId());
-        assertTrue(_match.exists(), "match should exist");
-
-        // advance match to end, this match will always advance to right tree
-        _playerToSeal = Util.advanceMatch(middleTournament, _matchId, _opponent);
-
-        // expect new inner created (middle 2)
-        vm.recordLogs();
-
-        // seal match
-        Util.sealInnerMatchAndCreateInnerTournament(
-            middleTournament, _matchId, _playerToSeal
-        );
-        _height += 1;
-
-        cycle = (
-            1
-                << (
-                    ArbitrationConstants.height(0)
-                        + ArbitrationConstants.log2step(0)
-                )
-        ) - (1 << ArbitrationConstants.log2step(1));
-        assertEq(
-            middleTournament.getMatchCycle(_matchId.hashFromId()),
-            cycle,
-            "agree cycle should be 4951760157141521099462279168"
-        );
-
-        _entries = vm.getRecordedLogs();
-        assertEq(_entries[0].topics.length, 2);
-        assertEq(
-            _entries[0].topics[0],
-            keccak256("newInnerTournament(bytes32,address)")
-        );
-        assertEq(
-            _entries[0].topics[1], Match.IdHash.unwrap(_matchId.hashFromId())
-        );
-
-        bottomTournament = BottomTournament(
-            address(bytes20(bytes32(_entries[0].data) << (12 * 8)))
-        );
-
-        Util.joinTournament(bottomTournament, 0);
-        Util.joinTournament(bottomTournament, _opponent);
-
-        _matchId = Util.matchId(_opponent, _height);
-        _match = bottomTournament.getMatch(_matchId.hashFromId());
-        assertTrue(_match.exists(), "match should exist");
-
-        // advance match to end, this match will always advance to right tree
-        _playerToSeal = Util.advanceMatch(bottomTournament, _matchId, _opponent);
-
-        // seal match
-        Util.sealLeafMatch(bottomTournament, _matchId, _playerToSeal);
-
-        cycle = (
-            1
-                << (
-                    ArbitrationConstants.height(0)
-                        + ArbitrationConstants.log2step(0)
-                )
-        ) - (1 << ArbitrationConstants.log2step(2));
-        assertEq(
-            bottomTournament.getMatchCycle(_matchId.hashFromId()),
-            cycle,
-            "agree cycle should be 4951760157141521099596496895"
-        );
-
-        vm.expectRevert();
-        // win match, expect revert
-        Util.winLeafMatch(bottomTournament, _matchId, _playerToSeal);
     }
 }

--- a/prt/contracts/test/MiddleTournament.t.sol
+++ b/prt/contracts/test/MiddleTournament.t.sol
@@ -32,7 +32,7 @@ contract MiddleTournamentTest is Util, Test {
     event newInnerTournament(Match.IdHash indexed, NonRootTournament);
 
     constructor() {
-        factory = Util.instantiateTournamentFactory();
+        (factory,) = Util.instantiateTournamentFactory();
     }
 
     function setUp() public {}

--- a/prt/contracts/test/StateTransition.t.sol
+++ b/prt/contracts/test/StateTransition.t.sol
@@ -1,0 +1,141 @@
+// Copyright 2023 Cartesi Pte. Ltd.
+
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+import "forge-std/Test.sol";
+
+import "./Util.sol";
+import "src/StateTransition.sol";
+
+pragma solidity ^0.8.0;
+
+contract StateTransitionTest is Util, Test {
+    StateTransition immutable stateTransition;
+    RiscVStateTransition immutable riscVStateTransition;
+    CmioStateTransition immutable cmioStateTransition;
+
+    constructor() {
+        (stateTransition, riscVStateTransition, cmioStateTransition) =
+            Util.instantiateStateTransition();
+    }
+
+    function testTransitionComputeReset() public {
+        AccessLogs.Context memory accessLogs = AccessLogs.Context(
+            bytes32(uint256(0x123)), Buffer.Context(new bytes(0), 0)
+        );
+
+        vm.mockCall(
+            address(riscVStateTransition),
+            abi.encode(riscVStateTransition.reset.selector),
+            abi.encode(accessLogs)
+        );
+
+        bytes32 mockState = stateTransition.transitionState(
+            bytes32(0),
+            4951760157141521099596496895,
+            new bytes(0),
+            IDataProvider(address(0))
+        );
+
+        assertEq(mockState, bytes32(uint256(0x123)));
+    }
+
+    function testTransitionComputeStep() public {
+        AccessLogs.Context memory accessLogs = AccessLogs.Context(
+            bytes32(uint256(0x321)), Buffer.Context(new bytes(0), 0)
+        );
+
+        vm.mockCall(
+            address(riscVStateTransition),
+            abi.encode(riscVStateTransition.step.selector),
+            abi.encode(accessLogs)
+        );
+
+        bytes32 mockState = stateTransition.transitionState(
+            bytes32(0), 0, new bytes(0), IDataProvider(address(0))
+        );
+
+        assertEq(mockState, bytes32(uint256(0x321)));
+    }
+
+    function testTransitionRollupsCmio() public {
+        AccessLogs.Context memory accessLogs = AccessLogs.Context(
+            bytes32(uint256(0x321)), Buffer.Context(new bytes(0), 0)
+        );
+
+        vm.mockCall(
+            address(0x123),
+            abi.encode(IDataProvider.provideMerkleRootOfInput.selector),
+            abi.encode(bytes32(uint256(0x123)))
+        );
+
+        vm.mockCall(
+            address(cmioStateTransition),
+            abi.encode(cmioStateTransition.sendCmio.selector),
+            abi.encode(accessLogs)
+        );
+
+        vm.mockCall(
+            address(riscVStateTransition),
+            abi.encode(riscVStateTransition.step.selector),
+            abi.encode(accessLogs)
+        );
+
+        uint256 length = 20;
+        bytes32 mockState = stateTransition.transitionState(
+            bytes32(0),
+            0,
+            abi.encodePacked(abi.encodePacked(length), new bytes(length)),
+            IDataProvider(address(0x123))
+        );
+
+        assertEq(mockState, bytes32(uint256(0x321)));
+    }
+
+    function testTransitionRollupsStep() public {
+        AccessLogs.Context memory accessLogs = AccessLogs.Context(
+            bytes32(uint256(0x321)), Buffer.Context(new bytes(0), 0)
+        );
+
+        vm.mockCall(
+            address(riscVStateTransition),
+            abi.encode(riscVStateTransition.step.selector),
+            abi.encode(accessLogs)
+        );
+
+        bytes32 mockState = stateTransition.transitionState(
+            bytes32(0), 1, new bytes(0), IDataProvider(address(0x123))
+        );
+
+        assertEq(mockState, bytes32(uint256(0x321)));
+    }
+
+    function testTransitionRollupsReset() public {
+        AccessLogs.Context memory accessLogs = AccessLogs.Context(
+            bytes32(uint256(0x123)), Buffer.Context(new bytes(0), 0)
+        );
+
+        vm.mockCall(
+            address(riscVStateTransition),
+            abi.encode(riscVStateTransition.reset.selector),
+            abi.encode(accessLogs)
+        );
+
+        bytes32 mockState = stateTransition.transitionState(
+            bytes32(0),
+            4951760157141521099596496895,
+            new bytes(0),
+            IDataProvider(address(0x123))
+        );
+
+        assertEq(mockState, bytes32(uint256(0x123)));
+    }
+}

--- a/prt/contracts/test/TopTournament.t.sol
+++ b/prt/contracts/test/TopTournament.t.sol
@@ -29,7 +29,7 @@ contract TopTournamentTest is Util, Test {
     TopTournament topTournament;
 
     constructor() {
-        factory = Util.instantiateTournamentFactory();
+        (factory,) = Util.instantiateTournamentFactory();
     }
 
     function setUp() public {}

--- a/prt/contracts/test/Tournament.t.sol
+++ b/prt/contracts/test/Tournament.t.sol
@@ -35,7 +35,7 @@ contract TournamentTest is Util, Test {
     );
 
     constructor() {
-        factory = Util.instantiateTournamentFactory();
+        (factory,) = Util.instantiateTournamentFactory();
     }
 
     function setUp() public {}

--- a/prt/contracts/test/TournamentFactory.t.sol
+++ b/prt/contracts/test/TournamentFactory.t.sol
@@ -27,7 +27,7 @@ contract TournamentFactoryTest is Util, Test {
 
     function setUp() public {
         singleLevelfactory = Util.instantiateSingleLevelTournamentFactory();
-        multiLevelfactory = Util.instantiateTournamentFactory();
+        (multiLevelfactory,) = Util.instantiateTournamentFactory();
     }
 
     function testRootTournament() public {


### PR DESCRIPTION
This has made all smart contracts 100% converage except the two:
```
CmioStateTransition.sol
RiscVStateTransition.sol
```
Which are merely redirection contract and their tests should be covered in the `machine-solidity-step` repo.

![image](https://github.com/user-attachments/assets/0c4ce38b-c524-4294-b0f0-51d376bb1a86)
![image](https://github.com/user-attachments/assets/a60ebd6c-e949-46ca-a80e-d6cc9007dd29)


Thanks to the `step` library->contract refactor, some tests are greatly simplified as well.