### PR TITLE
Add rollups echo test to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,7 @@ jobs:
           just test-rust-workspace
 
       - name: Test dave-rollups
+        if: startsWith(github.ref, 'refs/tags/v')
         working-directory: ./prt/tests/rollups
         run: |
           just test-echo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,11 @@ jobs:
         run: |
           just test-rust-workspace
 
+      - name: Test dave-rollups
+        working-directory: ./prt/tests/rollups
+        run: |
+          just test-echo
+
       - name: Build dave-rollups
         if: startsWith(github.ref, 'refs/tags/v')
         run: |

--- a/cartesi-rollups/contracts/src/DaveConsensus.sol
+++ b/cartesi-rollups/contracts/src/DaveConsensus.sol
@@ -9,6 +9,7 @@ import {IDataProvider} from "prt-contracts/IDataProvider.sol";
 import {ITournamentFactory} from "prt-contracts/ITournamentFactory.sol";
 import {ITournament} from "prt-contracts/ITournament.sol";
 import {Machine} from "prt-contracts/Machine.sol";
+import {Tree} from "prt-contracts/Tree.sol";
 
 import {Merkle} from "./Merkle.sol";
 
@@ -111,8 +112,8 @@ contract DaveConsensus is IDataProvider {
         emit EpochSealed(0, 0, inputIndexUpperBound, initialMachineStateHash, tournament);
     }
 
-    function canSettle() external view returns (bool isFinished, uint256 epochNumber) {
-        (isFinished,,) = _tournament.arbitrationResult();
+    function canSettle() external view returns (bool isFinished, uint256 epochNumber, Tree.Node winnerCommitment) {
+        (isFinished, winnerCommitment,) = _tournament.arbitrationResult();
         epochNumber = _epochNumber;
     }
 

--- a/cartesi-rollups/contracts/test/DaveConsensus.t.sol
+++ b/cartesi-rollups/contracts/test/DaveConsensus.t.sol
@@ -164,7 +164,7 @@ contract DaveConsensusTest is Test {
             bool isFinished;
             uint256 epochNumber;
 
-            (isFinished, epochNumber) = daveConsensus.canSettle();
+            (isFinished, epochNumber,) = daveConsensus.canSettle();
 
             assertFalse(isFinished);
             assertEq(epochNumber, 0);
@@ -217,7 +217,7 @@ contract DaveConsensusTest is Test {
             bool isFinished;
             uint256 epochNumber;
 
-            (isFinished, epochNumber) = daveConsensus.canSettle();
+            (isFinished, epochNumber,) = daveConsensus.canSettle();
 
             assertTrue(isFinished);
             assertEq(epochNumber, 0);
@@ -242,7 +242,7 @@ contract DaveConsensusTest is Test {
             bool isFinished;
             uint256 epochNumber;
 
-            (isFinished, epochNumber) = daveConsensus.canSettle();
+            (isFinished, epochNumber,) = daveConsensus.canSettle();
 
             assertFalse(isFinished);
             assertEq(epochNumber, 1);

--- a/cartesi-rollups/node/blockchain-reader/src/lib.rs
+++ b/cartesi-rollups/node/blockchain-reader/src/lib.rs
@@ -18,6 +18,7 @@ use async_recursion::async_recursion;
 use clap::Parser;
 use error::BlockchainReaderError;
 use log::{info, trace};
+use num_traits::cast::ToPrimitive;
 use std::{
     iter::Peekable,
     marker::{Send, Sync},
@@ -164,11 +165,11 @@ where
                 let epoch = Epoch {
                     epoch_number: e
                         .epochNumber
-                        .try_into()
+                        .to_u64()
                         .expect("fail to convert epoch number"),
                     input_index_boundary: e
                         .inputIndexUpperBound
-                        .try_into()
+                        .to_u64()
                         .expect("fail to convert epoch boundary"),
                     root_tournament: e.tournament.to_string(),
                 };

--- a/machine/rust-bindings/cartesi-machine-sys/build.rs
+++ b/machine/rust-bindings/cartesi-machine-sys/build.rs
@@ -30,6 +30,7 @@ fn main() {
     }
 
     // static link
+    println!("cargo:rustc-link-lib=slirp");
     cfg_if::cfg_if! {
         if #[cfg(feature = "remote_machine")] {
             println!("cargo:rustc-link-lib=static=cartesi_jsonrpc");

--- a/prt/tests/common/blockchain/node.lua
+++ b/prt/tests/common/blockchain/node.lua
@@ -9,13 +9,13 @@ local function start_blockchain(load_state)
     local cmd
     if load_state then
         cmd = string.format(
-            [[sh -c "echo $$ ; exec anvil --load-state %s --preserve-historical-states --block-time 1 --slots-in-an-epoch 1 -a %d > anvil.log 2>&1"]],
+            [[echo $$ ; exec anvil --load-state %s --preserve-historical-states --block-time 1 --slots-in-an-epoch 1 -a %d > anvil.log 2>&1]],
             load_state,
             default_account_number
         )
     else
         cmd = string.format(
-            [[sh -c "echo $$ ; exec anvil --preserve-historical-states --block-time 1 --slots-in-an-epoch 1 -a %d > anvil.log 2>&1"]],
+            [[echo $$ ; exec anvil --preserve-historical-states --block-time 1 --slots-in-an-epoch 1 -a %d > anvil.log 2>&1]],
             default_account_number
         )
     end

--- a/prt/tests/common/runners/rust_hero_runner.lua
+++ b/prt/tests/common/runners/rust_hero_runner.lua
@@ -27,8 +27,8 @@ end
 -- The Rust Compute reacts once and exits, the coroutine periodically spawn a new process until the tournament ends
 local function create_react_once_runner(player_id, machine_path)
     local rust_compute_cmd = string.format(
-        [[sh -c "echo $$ ; exec env MACHINE_PATH='%s' RUST_LOG='info' \
-        ./cartesi-prt-compute 2>&1 | tee -a honest.log"]],
+        [[echo $$ ; exec env MACHINE_PATH='%s' RUST_LOG='info' \
+        ./cartesi-prt-compute 2>&1 | tee -a honest.log]],
         machine_path)
 
     return coroutine.create(function()
@@ -61,8 +61,8 @@ end
 local function create_runner(player_id, machine_path)
     local hero_react_interval = 3
     local rust_compute_cmd = string.format(
-        [[sh -c "echo $$ ; exec env INTERVAL='%d' MACHINE_PATH='%s' RUST_LOG='info' \
-    ./cartesi-prt-compute 2>&1 | tee honest.log"]],
+        [[echo $$ ; exec env INTERVAL='%d' MACHINE_PATH='%s' RUST_LOG='info' \
+    ./cartesi-prt-compute 2>&1 | tee honest.log]],
         hero_react_interval, machine_path)
 
     return coroutine.create(function()

--- a/prt/tests/rollups/check_rollups_winner.lua
+++ b/prt/tests/rollups/check_rollups_winner.lua
@@ -21,7 +21,7 @@ for line in file:lines() do
     local commitment_join = line:match("join tournament .- level 0 with commitment (0x%x+)")
 
     -- Pattern to match the winner commitments
-    local commitment_winner = line:match("tournament finished, winner commitment: (0x%x+)")
+    local commitment_winner = line:match("settle epoch %d+ with claim (0x%x+)")
 
     if commitment_join and not joined_commitments[commitment_join] and joined_count < MAX_EPOCH then
         joined_commitments[commitment_join] = true

--- a/prt/tests/rollups/check_rollups_winner.lua
+++ b/prt/tests/rollups/check_rollups_winner.lua
@@ -1,0 +1,60 @@
+local input_file = "dave.log"
+local MAX_EPOCH = tonumber(os.getenv("MAX_EPOCH")) or false -- number of epochs to check winner
+
+local joined_commitments = {}                               -- Table to store joined commitments
+local winner_commitments = {}                               -- Table to store winner commitments
+local joined_count = 0
+local winner_count = 0
+
+-- Open the file for reading
+local file = io.open(input_file, "r")
+if not file then
+    print("Could not open file: " .. input_file)
+    return
+end
+
+print("Checking result of tournaments...")
+
+-- Read from the file
+for line in file:lines() do
+    -- Pattern to match the commitments that join level 0 tournament
+    local commitment_join = line:match("join tournament .- level 0 with commitment (0x%x+)")
+
+    -- Pattern to match the winner commitments
+    local commitment_winner = line:match("tournament finished, winner commitment: (0x%x+)")
+
+    if commitment_join and not joined_commitments[commitment_join] and joined_count < MAX_EPOCH then
+        joined_commitments[commitment_join] = true
+        print(string.format("Root commitment joined: %s", commitment_join))
+        joined_count = joined_count + 1
+    end
+
+    if commitment_winner and not winner_commitments[commitment_winner] and winner_count < MAX_EPOCH then
+        winner_commitments[commitment_winner] = true
+        print(string.format("Winner commitment: %s", commitment_winner))
+        winner_count = winner_count + 1
+    end
+
+    -- Break if we have reached the maximum for both
+    if joined_count >= MAX_EPOCH and winner_count >= MAX_EPOCH then
+        break
+    end
+end
+
+-- Close the file
+file:close()
+
+-- Check if all joined commitments are also winner commitments
+local all_joined_are_winners = true
+for commitment in pairs(joined_commitments) do
+    if not winner_commitments[commitment] then
+        all_joined_are_winners = false
+        print(string.format("Commitment didn't win: %s", commitment))
+    end
+end
+
+if all_joined_are_winners then
+    print("Dave won all tournaments.")
+else
+    error("Dave didn't win all tournaments.")
+end

--- a/prt/tests/rollups/dave/node.lua
+++ b/prt/tests/rollups/dave/node.lua
@@ -2,11 +2,11 @@ local helper = require "utils.helper"
 
 local function start_dave_node(machine_path, db_path, consensus, input_box, sleep_duration, verbosity, trace_level)
     local cmd = string.format(
-        [[sh -c "echo $$ ; exec env MACHINE_PATH='%s' STATE_DIR='%s' \
+        [[echo $$ ; exec env MACHINE_PATH='%s' STATE_DIR='%s' \
         CONSENSUS='%s' INPUT_BOX='%s' \
         SLEEP_DURATION=%d RUST_BACKTRACE='%s' \
         RUST_LOG='none',cartesi_prt_core='%s',rollups_prt_runner='%s',rollups_epoch_manager='%s' \
-        ../../../target/debug/dave-rollups > dave.log 2>&1"]],
+        ../../../target/debug/dave-rollups > dave.log 2>&1]],
         machine_path, db_path, consensus, input_box, sleep_duration, trace_level, verbosity, verbosity, verbosity
     )
 

--- a/prt/tests/rollups/justfile
+++ b/prt/tests/rollups/justfile
@@ -5,7 +5,7 @@ HONEYPOT_DIR := "../../../test/programs/honeypot"
 INPUT_BOX := `head -n 1 ../../../test/programs/echo/addresses`
 CONSENSUS := `head -n 2 ../../../test/programs/echo/addresses | tail -n 1`
 
-MAX_EPOCH := "2"
+MAX_EPOCH := "1"
 
 # run PRT rollups test
 test MACH_PATH:

--- a/prt/tests/rollups/justfile
+++ b/prt/tests/rollups/justfile
@@ -5,12 +5,16 @@ HONEYPOT_DIR := "../../../test/programs/honeypot"
 INPUT_BOX := `head -n 1 ../../../test/programs/echo/addresses`
 CONSENSUS := `head -n 2 ../../../test/programs/echo/addresses | tail -n 1`
 
+MAX_EPOCH := "2"
+
 # run PRT rollups test
 test MACH_PATH:
   rm -rf _state
   CONSENSUS={{CONSENSUS}} \
   INPUT_BOX={{INPUT_BOX}} \
-  MACHINE_PATH={{MACH_PATH}} lua prt_rollups.lua
+  MACHINE_PATH={{MACH_PATH}} \
+  MAX_EPOCH={{MAX_EPOCH}} lua prt_rollups.lua && \
+  MAX_EPOCH={{MAX_EPOCH}} lua check_rollups_winner.lua
 
 # run PRT rollups echo test
 test-echo:

--- a/prt/tests/rollups/prt_rollups.lua
+++ b/prt/tests/rollups/prt_rollups.lua
@@ -4,6 +4,8 @@ require "setup_path"
 local CONSENSUS_ADDRESS = os.getenv("CONSENSUS") or "0x0165878A594ca255338adfa4d48449f69242Eb8F"
 -- input contract address in anvil deployment
 local INPUT_BOX_ADDRESS = os.getenv("INPUT_BOX") or "0x5FbDB2315678afecb367f032d93F642f64180aa3";
+-- number of epochs to run the rollups test
+local MAX_EPOCH = tonumber(os.getenv("MAX_EPOCH")) or false
 
 -- amount of time sleep between each react
 local SLEEP_TIME = 2
@@ -193,11 +195,18 @@ local reader = Reader:new(blockchain_constants.endpoint)
 local sender = Sender:new(blockchain_constants.pks[1], blockchain_constants.endpoint)
 
 print("Hello from Dave rollups lua prototype!")
+if MAX_EPOCH then
+    print(string.format("rollups test will only run %d epochs", MAX_EPOCH))
+end
 
 local input_index = 1
-
 while true do
     local sealed_epochs = reader:read_epochs_sealed(CONSENSUS_ADDRESS)
+
+    if #sealed_epochs > MAX_EPOCH then
+        print(string.format("rollups test ends with %d epochs", MAX_EPOCH))
+        break
+    end
 
     if #sealed_epochs > 0 then
         local last_sealed_epoch = sealed_epochs[#sealed_epochs]

--- a/prt/tests/rollups/prt_rollups.lua
+++ b/prt/tests/rollups/prt_rollups.lua
@@ -10,7 +10,7 @@ local MAX_EPOCH = tonumber(os.getenv("MAX_EPOCH")) or false
 -- amount of time sleep between each react
 local SLEEP_TIME = 2
 -- amount of blocks to fastforward if all players are idle
-local FAST_FORWARD_TIME = 320
+local FAST_FORWARD_TIME = 32
 -- delay time for background software to be ready
 local NODE_DELAY = 3
 -- number of fake commitment to make
@@ -166,7 +166,7 @@ local function run_players(player_coroutines)
         end
 
         -- 4 consecutive idle will advance blockchain for faster outcome
-        if idle_1 and idle_2 and idle_3 and idle then
+        if idle and idle_1 and idle_2 and idle_3 then
             print(string.format("All players idle, fastforward blockchain for %d blocks...", FAST_FORWARD_TIME))
             blockchain_utils.advance_time(FAST_FORWARD_TIME, blockchain_constants.endpoint)
         end
@@ -232,4 +232,3 @@ while true do
 end
 
 print("Good-bye, world!")
-time.sleep(NODE_DELAY)


### PR DESCRIPTION
@guidanoli Please let me know if you have any concern of adding `winnerCommitment` to the `canSettle` function return values.
CI is running three times as slow as my laptop. Anyways the test finishes in 15 minutes. I'm not sure if it should be enabled for all pushes, or only for tag/releases. What do you think @GCdePaula ?