### PR TITLE
fix: remove bad error case in `prt_rollups.lua`

### DIFF
--- a/prt/tests/rollups/prt_rollups.lua
+++ b/prt/tests/rollups/prt_rollups.lua
@@ -224,8 +224,6 @@ while true do
             local epoch_machine_path = string.format("./_state/snapshots/%d/0", last_sealed_epoch.epoch_number)
             local player_coroutines = setup_players(root_tournament, epoch_machine_path)
             run_players(player_coroutines)
-        else
-            error("work directory doesn't exist!")
         end
     end
     time.sleep(SLEEP_TIME)


### PR DESCRIPTION
Dave node and Lua orchestrator are working asynchronously, so it could happen that Dave node hasn't created the `work directory` yet. Lua script should just wait instead of throwing an error. I don't know why I added that error case in my previous commit. It was clearly a mistake.