### PR TITLE
Turn on optimizer

### DIFF
--- a/cartesi-rollups/contracts/.gitignore
+++ b/cartesi-rollups/contracts/.gitignore
@@ -17,3 +17,6 @@ docs/
 
 # Dotenv file
 .env
+
+# Gas snapshot
+.gas-snapshot

--- a/cartesi-rollups/contracts/foundry.toml
+++ b/cartesi-rollups/contracts/foundry.toml
@@ -2,6 +2,7 @@
 src = "src"
 out = "out"
 libs = ["dependencies", "../../prt/contracts", "../../machine/step"]
+optimizer = true
 via_ir = true
 
 remappings = [

--- a/prt/contracts/.gitignore
+++ b/prt/contracts/.gitignore
@@ -17,3 +17,6 @@ docs/
 report
 lcov.info
 lcov.info.pruned
+
+# Gas snapshot
+.gas-snapshot

--- a/prt/contracts/foundry.toml
+++ b/prt/contracts/foundry.toml
@@ -3,6 +3,7 @@ src = "src"
 out = "out"
 libs = ["lib"]
 via_ir = true
+optimizer = true
 
 allow_paths = ['../../machine/step/']
 remappings = [


### PR DESCRIPTION
Foundry v1.0.0 introduces the following breaking change:

> [solc optimizer disabled by default](https://book.getfoundry.sh/reference/config/solidity-compiler#optimizer-1) ([#2486](https://github.com/foundry-rs/foundry/issues/2486))

So we must explicitly set `optimizer` to `true` in our `foundry.toml` files:

```yaml
optimizer = true
```

This PR also makes git ignore `.gas-snapshot` files in forge projects.
The `forge snapshot` command generates this file.