### PR TITLE
Make factories instantiate EIP-1167 "minimal proxies"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "machine/step"]
 	path = machine/step
 	url = https://github.com/cartesi/machine-solidity-step
-[submodule "prt/contracts/lib/forge-std"]
-	path = prt/contracts/lib/forge-std
-	url = https://github.com/foundry-rs/forge-std
 [submodule "machine/emulator"]
 	path = machine/emulator
 	url = https://github.com/cartesi/machine-emulator

--- a/cartesi-rollups/contracts/.gitignore
+++ b/cartesi-rollups/contracts/.gitignore
@@ -2,7 +2,6 @@
 cache/
 out/
 
-
 # soldeer
 /dependencies
 remappings.txt

--- a/cartesi-rollups/contracts/foundry.toml
+++ b/cartesi-rollups/contracts/foundry.toml
@@ -6,8 +6,6 @@ optimizer = true
 via_ir = true
 
 remappings = [
-    '@openzeppelin-contracts-5.2.0/=dependencies/@openzeppelin-contracts-5.2.0/',
-    'forge-std-1.9.6/=dependencies/forge-std-1.9.6/',
     'cartesi-rollups-contracts-2.0.0/=dependencies/cartesi-rollups-contracts-2.0.0-rc.17/src/',
 
     'prt-contracts/=../../prt/contracts/src/',

--- a/cartesi-rollups/contracts/foundry.toml
+++ b/cartesi-rollups/contracts/foundry.toml
@@ -1,10 +1,11 @@
 [profile.default]
 src = "src"
 out = "out"
-libs = ["dependencies", "../../prt/contracts", "../../machine/step"]
+libs = ["dependencies"]
 optimizer = true
 via_ir = true
 
+allow_paths = ["../../prt/contracts", "../../machine/step"]
 remappings = [
     'cartesi-rollups-contracts-2.0.0/=dependencies/cartesi-rollups-contracts-2.0.0-rc.17/src/',
 

--- a/cartesi-rollups/contracts/script/DaveConsensus.s.sol
+++ b/cartesi-rollups/contracts/script/DaveConsensus.s.sol
@@ -22,9 +22,9 @@ contract DaveConsensusScript is Script {
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
 
         MultiLevelTournamentFactory factory = new MultiLevelTournamentFactory(
-            new TopTournamentFactory(),
-            new MiddleTournamentFactory(),
-            new BottomTournamentFactory(),
+            new TopTournamentFactory(new TopTournament()),
+            new MiddleTournamentFactory(new MiddleTournament()),
+            new BottomTournamentFactory(new BottomTournament()),
             new TestTournamentParametersProvider(),
             new CartesiStateTransition(new RiscVStateTransition(), new CmioStateTransition())
         );

--- a/cartesi-rollups/contracts/script/DaveConsensus.s.sol
+++ b/cartesi-rollups/contracts/script/DaveConsensus.s.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.17;
 
-import {Script} from "forge-std/Script.sol";
+import {Script} from "forge-std-1.9.6/src/Script.sol";
 
 import {Machine} from "prt-contracts/types/Machine.sol";
 import "prt-contracts/tournament/factories/MultiLevelTournamentFactory.sol";

--- a/cartesi-rollups/contracts/script/InputBox.s.sol
+++ b/cartesi-rollups/contracts/script/InputBox.s.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.17;
 
-import {Script} from "forge-std/Script.sol";
+import {Script} from "forge-std-1.9.6/src/Script.sol";
 
 import "cartesi-rollups-contracts-2.0.0/inputs/InputBox.sol";
 

--- a/cartesi-rollups/contracts/test/Math.t.sol
+++ b/cartesi-rollups/contracts/test/Math.t.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.0;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 import {Math} from "src/Math.sol";
 

--- a/cartesi-rollups/contracts/test/Merkle.t.sol
+++ b/cartesi-rollups/contracts/test/Merkle.t.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.0;
 
-import {Test} from "forge-std/Test.sol";
+import {Test} from "forge-std-1.9.6/src/Test.sol";
 
 import {MerkleConstants} from "src/MerkleConstants.sol";
 import {PristineMerkleTree} from "src/PristineMerkleTree.sol";

--- a/justfile
+++ b/justfile
@@ -19,6 +19,7 @@ setup-docker: setup build-docker-image
 
 # Run this once after cloning, if using local environment
 setup-local: setup
+  just -f ./prt/contracts/justfile install-deps
   just -f ./cartesi-rollups/contracts/justfile install-deps
   just -f ./test/programs/justfile download-deps
   just -f ./test/programs/justfile build-programs

--- a/prt/client-rs/core/src/tournament/reader.rs
+++ b/prt/client-rs/core/src/tournament/reader.rs
@@ -201,7 +201,7 @@ impl StateReader {
             state.log2_stride,
             state.log2_stride_count,
         ) = (
-            level_constants_return._max_level,
+            level_constants_return._maxLevel,
             level_constants_return._level,
             level_constants_return._log2step,
             level_constants_return._height,

--- a/prt/contracts/.gitignore
+++ b/prt/contracts/.gitignore
@@ -2,6 +2,10 @@
 cache/
 out/
 
+# soldeer
+/dependencies
+remappings.txt
+
 # Ignores development broadcast logs
 !/broadcast
 /broadcast/*/31337/

--- a/prt/contracts/cannonfile.toml
+++ b/prt/contracts/cannonfile.toml
@@ -21,18 +21,36 @@ args = [
 create2 = true
 salt = "<%= zeroHash %>"
 
+[deploy.TopTournament]
+artifact = "TopTournament"
+create2 = true
+salt = "<%= zeroHash %>"
+
 [deploy.TopTournamentFactory]
 artifact = "TopTournamentFactory"
+args = ["<%= contracts.TopTournament.address %>"]
+create2 = true
+salt = "<%= zeroHash %>"
+
+[deploy.MiddleTournament]
+artifact = "MiddleTournament"
 create2 = true
 salt = "<%= zeroHash %>"
 
 [deploy.MiddleTournamentFactory]
 artifact = "MiddleTournamentFactory"
+args = ["<%= contracts.MiddleTournament.address %>"]
+create2 = true
+salt = "<%= zeroHash %>"
+
+[deploy.BottomTournament]
+artifact = "BottomTournament"
 create2 = true
 salt = "<%= zeroHash %>"
 
 [deploy.BottomTournamentFactory]
 artifact = "BottomTournamentFactory"
+args = ["<%= contracts.BottomTournament.address %>"]
 create2 = true
 salt = "<%= zeroHash %>"
 

--- a/prt/contracts/foundry.toml
+++ b/prt/contracts/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 src = "src"
 out = "out"
-libs = ["lib"]
+libs = ["dependencies"]
 via_ir = true
 optimizer = true
 
@@ -15,3 +15,6 @@ solc-version = "0.8.27"
 [fmt]
 line_length = 80
 tab_width = 4
+
+[dependencies]
+forge-std = "1.9.6"

--- a/prt/contracts/foundry.toml
+++ b/prt/contracts/foundry.toml
@@ -18,3 +18,4 @@ tab_width = 4
 
 [dependencies]
 forge-std = "1.9.6"
+"@openzeppelin-contracts" = "5.2.0"

--- a/prt/contracts/justfile
+++ b/prt/contracts/justfile
@@ -30,6 +30,9 @@ fmt:
 check-fmt:
     forge fmt --check
 
+install-deps:
+   forge soldeer install
+
 clean-bindings:
     rm -rf {{BINDINGS_DIR}}
 

--- a/prt/contracts/script/TopTournament.s.sol
+++ b/prt/contracts/script/TopTournament.s.sol
@@ -20,9 +20,9 @@ contract TopTournamentScript is Script {
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
 
         MultiLevelTournamentFactory factory = new MultiLevelTournamentFactory(
-            new TopTournamentFactory(),
-            new MiddleTournamentFactory(),
-            new BottomTournamentFactory(),
+            new TopTournamentFactory(new TopTournament()),
+            new MiddleTournamentFactory(new MiddleTournament()),
+            new BottomTournamentFactory(new BottomTournament()),
             new CanonicalTournamentParametersProvider(),
             new CartesiStateTransition(
                 new RiscVStateTransition(), new CmioStateTransition()

--- a/prt/contracts/script/TopTournament.s.sol
+++ b/prt/contracts/script/TopTournament.s.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.17;
 
-import {Script} from "forge-std/Script.sol";
+import {Script} from "forge-std-1.9.6/src/Script.sol";
 
 import {Machine} from "src/types/Machine.sol";
 

--- a/prt/contracts/soldeer.lock
+++ b/prt/contracts/soldeer.lock
@@ -1,0 +1,6 @@
+[[dependencies]]
+name = "forge-std"
+version = "1.9.6"
+url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_9_6_01-02-2025_20:49:10_forge-std-1.9.zip"
+checksum = "55f341818321b3f925161a72fd0dcd62e4a0a4b66785a7a932bf2bfaf96fb9d1"
+integrity = "e9ecdc364d152157431e5df5aa041ffddbe9bb1c1ad81634b1e72df9e23814e8"

--- a/prt/contracts/soldeer.lock
+++ b/prt/contracts/soldeer.lock
@@ -1,4 +1,11 @@
 [[dependencies]]
+name = "@openzeppelin-contracts"
+version = "5.2.0"
+url = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/5_2_0_11-01-2025_09:30:20_contracts.zip"
+checksum = "6dbd0440446b2ed16ca25e9f1af08fc0c5c1e73e71fee86ae8a00daa774e3817"
+integrity = "4cb7f3777f67fdf4b7d0e2f94d2f93f198b2e5dce718b7062ac7c2c83e1183bd"
+
+[[dependencies]]
 name = "forge-std"
 version = "1.9.6"
 url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_9_6_01-02-2025_20:49:10_forge-std-1.9.zip"

--- a/prt/contracts/src/tournament/abstracts/LeafTournament.sol
+++ b/prt/contracts/src/tournament/abstracts/LeafTournament.sol
@@ -39,12 +39,7 @@ abstract contract LeafTournament is Tournament {
             _clock2.advanceClock();
         }
 
-        Machine.Hash initialHash;
-        {
-            TournamentArgs memory args;
-            args = _tournamentArgs();
-            initialHash = args.initialHash;
-        }
+        Machine.Hash initialHash = _tournamentArgs().initialHash;
         _matchState.sealMatch(
             _matchId,
             initialHash,

--- a/prt/contracts/src/tournament/abstracts/NonLeafTournament.sol
+++ b/prt/contracts/src/tournament/abstracts/NonLeafTournament.sol
@@ -46,20 +46,11 @@ abstract contract NonLeafTournament is Tournament {
             _clock2.setPaused();
             _maxDuration = Clock.max(_clock1, _clock2);
         }
-        Machine.Hash initialHash;
-        uint256 startCycle;
-        uint64 level;
-        {
-            TournamentArgs memory args;
-            args = _tournamentArgs();
-            initialHash = args.initialHash;
-            startCycle = args.startCycle;
-            level = args.level;
-        }
+        TournamentArgs memory args = _tournamentArgs();
         (Machine.Hash _finalStateOne, Machine.Hash _finalStateTwo) = _matchState
             .sealMatch(
             _matchId,
-            initialHash,
+            args.initialHash,
             _leftLeaf,
             _rightLeaf,
             _agreeHash,
@@ -72,8 +63,8 @@ abstract contract NonLeafTournament is Tournament {
             _matchId.commitmentTwo,
             _finalStateTwo,
             _maxDuration,
-            _matchState.toCycle(startCycle),
-            level + 1
+            _matchState.toCycle(args.startCycle),
+            args.level + 1
         );
         matchIdFromInnerTournaments[_inner] = _matchId.hashFromId();
 
@@ -132,18 +123,10 @@ abstract contract NonLeafTournament is Tournament {
     ) private returns (NonRootTournament) {
         // the inner tournament is bottom tournament at last level
         // else instantiate middle tournament
-        uint256 levels;
-        IDataProvider provider;
-        {
-            TournamentArgs memory args;
-            args = _tournamentArgs();
-            levels = args.levels;
-            provider = args.provider;
-        }
+        TournamentArgs memory args = _tournamentArgs();
         Tournament _tournament;
-        IMultiLevelTournamentFactory tournamentFactory;
-        tournamentFactory = _tournamentFactory();
-        if (_level == levels - 1) {
+        IMultiLevelTournamentFactory tournamentFactory = _tournamentFactory();
+        if (_level == args.levels - 1) {
             _tournament = tournamentFactory.instantiateBottom(
                 _initialHash,
                 _contestedCommitmentOne,
@@ -153,7 +136,7 @@ abstract contract NonLeafTournament is Tournament {
                 _allowance,
                 _startCycle,
                 _level,
-                provider
+                args.provider
             );
         } else {
             _tournament = tournamentFactory.instantiateMiddle(
@@ -165,7 +148,7 @@ abstract contract NonLeafTournament is Tournament {
                 _allowance,
                 _startCycle,
                 _level,
-                provider
+                args.provider
             );
         }
 

--- a/prt/contracts/src/tournament/abstracts/NonRootTournament.sol
+++ b/prt/contracts/src/tournament/abstracts/NonRootTournament.sol
@@ -39,24 +39,12 @@ abstract contract NonRootTournament is Tournament {
 
         Machine.Hash _finalState = finalStates[_danglingCommitment];
 
-        Machine.Hash contestedFinalStateOne;
-        Tree.Node contestedCommitmentOne;
-        Machine.Hash contestedFinalStateTwo;
-        Tree.Node contestedCommitmentTwo;
-        {
-            NonRootTournamentArgs memory args;
-            args = _nonRootTournamentArgs();
-            contestedFinalStateOne = args.contestedFinalStateOne;
-            contestedCommitmentOne = args.contestedCommitmentOne;
-            contestedFinalStateTwo = args.contestedFinalStateTwo;
-            contestedCommitmentTwo = args.contestedCommitmentTwo;
-        }
-
-        if (_finalState.eq(contestedFinalStateOne)) {
-            return (true, contestedCommitmentOne, _danglingCommitment);
+        NonRootTournamentArgs memory args = _nonRootTournamentArgs();
+        if (_finalState.eq(args.contestedFinalStateOne)) {
+            return (true, args.contestedCommitmentOne, _danglingCommitment);
         } else {
-            assert(_finalState.eq(contestedFinalStateTwo));
-            return (true, contestedCommitmentTwo, _danglingCommitment);
+            assert(_finalState.eq(args.contestedFinalStateTwo));
+            return (true, args.contestedCommitmentTwo, _danglingCommitment);
         }
     }
 
@@ -67,20 +55,12 @@ abstract contract NonRootTournament is Tournament {
         override
         returns (bool, Machine.Hash, Machine.Hash)
     {
-        Machine.Hash contestedFinalStateOne;
-        Machine.Hash contestedFinalStateTwo;
-        {
-            NonRootTournamentArgs memory args;
-            args = _nonRootTournamentArgs();
-            contestedFinalStateOne = args.contestedFinalStateOne;
-            contestedFinalStateTwo = args.contestedFinalStateTwo;
-        }
-
+        NonRootTournamentArgs memory args = _nonRootTournamentArgs();
         return (
-            contestedFinalStateOne.eq(_finalState)
-                || contestedFinalStateTwo.eq(_finalState),
-            contestedFinalStateOne,
-            contestedFinalStateTwo
+            args.contestedFinalStateOne.eq(_finalState)
+                || args.contestedFinalStateTwo.eq(_finalState),
+            args.contestedFinalStateOne,
+            args.contestedFinalStateTwo
         );
     }
 

--- a/prt/contracts/src/tournament/abstracts/RootTournament.sol
+++ b/prt/contracts/src/tournament/abstracts/RootTournament.sol
@@ -9,24 +9,6 @@ import "prt-contracts/types/TournamentParameters.sol";
 
 /// @notice Root tournament has no parent
 abstract contract RootTournament is Tournament, ITournament {
-    //
-    // Constructor
-    //
-    constructor(
-        Machine.Hash _initialHash,
-        TournamentParameters memory _tournamentParameters,
-        IDataProvider _provider
-    )
-        Tournament(
-            _initialHash,
-            _tournamentParameters.maxAllowance,
-            0,
-            0,
-            _tournamentParameters,
-            _provider
-        )
-    {}
-
     function validContestedFinalState(Machine.Hash)
         internal
         pure

--- a/prt/contracts/src/tournament/abstracts/Tournament.sol
+++ b/prt/contracts/src/tournament/abstracts/Tournament.sol
@@ -274,12 +274,7 @@ abstract contract Tournament {
         returns (uint256)
     {
         Match.State memory _m = getMatch(_matchIdHash);
-        uint256 startCycle;
-        {
-            TournamentArgs memory args;
-            args = _tournamentArgs();
-            startCycle = args.startCycle;
-        }
+        uint256 startCycle = _tournamentArgs().startCycle;
         return _m.toCycle(startCycle);
     }
 

--- a/prt/contracts/src/tournament/concretes/BottomTournament.sol
+++ b/prt/contracts/src/tournament/concretes/BottomTournament.sol
@@ -3,38 +3,49 @@
 
 pragma solidity ^0.8.17;
 
+import {Clones} from "@openzeppelin-contracts-5.2.0/proxy/Clones.sol";
+
 import "prt-contracts/tournament/abstracts/LeafTournament.sol";
 import "prt-contracts/tournament/abstracts/NonRootTournament.sol";
 
-import "prt-contracts/types/TournamentParameters.sol";
-
 /// @notice Bottom tournament of a multi-level instance
 contract BottomTournament is LeafTournament, NonRootTournament {
-    constructor(
-        Machine.Hash _initialHash,
-        Tree.Node _contestedCommitmentOne,
-        Machine.Hash _contestedFinalStateOne,
-        Tree.Node _contestedCommitmentTwo,
-        Machine.Hash _contestedFinalStateTwo,
-        Time.Duration _allowance,
-        uint256 _startCycle,
-        uint64 _level,
-        TournamentParameters memory _tournamentParameters,
-        IDataProvider _provider,
-        IStateTransition _stateTransition
-    )
-        LeafTournament(_stateTransition)
-        NonRootTournament(
-            _initialHash,
-            _contestedCommitmentOne,
-            _contestedFinalStateOne,
-            _contestedCommitmentTwo,
-            _contestedFinalStateTwo,
-            _allowance,
-            _startCycle,
-            _level,
-            _tournamentParameters,
-            _provider
-        )
-    {}
+    using Clones for address;
+
+    struct Args {
+        TournamentArgs tournamentArgs;
+        NonRootTournamentArgs nonRootTournamentArgs;
+        IStateTransition stateTransition;
+    }
+
+    function _args() internal view returns (Args memory) {
+        return abi.decode(address(this).fetchCloneArgs(), (Args));
+    }
+
+    function _tournamentArgs()
+        internal
+        view
+        override
+        returns (TournamentArgs memory)
+    {
+        return _args().tournamentArgs;
+    }
+
+    function _nonRootTournamentArgs()
+        internal
+        view
+        override
+        returns (NonRootTournamentArgs memory)
+    {
+        return _args().nonRootTournamentArgs;
+    }
+
+    function _stateTransition()
+        internal
+        view
+        override
+        returns (IStateTransition)
+    {
+        return _args().stateTransition;
+    }
 }

--- a/prt/contracts/src/tournament/concretes/MiddleTournament.sol
+++ b/prt/contracts/src/tournament/concretes/MiddleTournament.sol
@@ -3,39 +3,51 @@
 
 pragma solidity ^0.8.17;
 
+import {Clones} from "@openzeppelin-contracts-5.2.0/proxy/Clones.sol";
+
 import "prt-contracts/tournament/abstracts/NonLeafTournament.sol";
 import "prt-contracts/tournament/abstracts/NonRootTournament.sol";
 
-import "prt-contracts/types/TournamentParameters.sol";
 import "prt-contracts/tournament/factories/IMultiLevelTournamentFactory.sol";
 
 /// @notice Middle tournament is non-top, non-bottom of a multi-level instance
 contract MiddleTournament is NonLeafTournament, NonRootTournament {
-    constructor(
-        Machine.Hash _initialHash,
-        Tree.Node _contestedCommitmentOne,
-        Machine.Hash _contestedFinalStateOne,
-        Tree.Node _contestedCommitmentTwo,
-        Machine.Hash _contestedFinalStateTwo,
-        Time.Duration _allowance,
-        uint256 _startCycle,
-        uint64 _level,
-        TournamentParameters memory _tournamentParameters,
-        IDataProvider _provider,
-        IMultiLevelTournamentFactory _tournamentFactory
-    )
-        NonLeafTournament(_tournamentFactory)
-        NonRootTournament(
-            _initialHash,
-            _contestedCommitmentOne,
-            _contestedFinalStateOne,
-            _contestedCommitmentTwo,
-            _contestedFinalStateTwo,
-            _allowance,
-            _startCycle,
-            _level,
-            _tournamentParameters,
-            _provider
-        )
-    {}
+    using Clones for address;
+
+    struct Args {
+        TournamentArgs tournamentArgs;
+        NonRootTournamentArgs nonRootTournamentArgs;
+        IMultiLevelTournamentFactory tournamentFactory;
+    }
+
+    function _args() internal view returns (Args memory) {
+        return abi.decode(address(this).fetchCloneArgs(), (Args));
+    }
+
+    function _tournamentArgs()
+        internal
+        view
+        override
+        returns (TournamentArgs memory)
+    {
+        return _args().tournamentArgs;
+    }
+
+    function _nonRootTournamentArgs()
+        internal
+        view
+        override
+        returns (NonRootTournamentArgs memory)
+    {
+        return _args().nonRootTournamentArgs;
+    }
+
+    function _tournamentFactory()
+        internal
+        view
+        override
+        returns (IMultiLevelTournamentFactory)
+    {
+        return _args().tournamentFactory;
+    }
 }

--- a/prt/contracts/src/tournament/concretes/SingleLevelTournament.sol
+++ b/prt/contracts/src/tournament/concretes/SingleLevelTournament.sol
@@ -3,19 +3,38 @@
 
 pragma solidity ^0.8.17;
 
-import "prt-contracts/tournament/abstracts/RootTournament.sol";
-import "prt-contracts/tournament/abstracts/LeafTournament.sol";
+import {Clones} from "@openzeppelin-contracts-5.2.0/proxy/Clones.sol";
 
-import "prt-contracts/types/TournamentParameters.sol";
+import "prt-contracts/tournament/abstracts/LeafTournament.sol";
+import "prt-contracts/tournament/abstracts/RootTournament.sol";
 
 contract SingleLevelTournament is LeafTournament, RootTournament {
-    constructor(
-        Machine.Hash _initialHash,
-        TournamentParameters memory _tournamentParameters,
-        IDataProvider _provider,
-        IStateTransition _stateTransition
-    )
-        LeafTournament(_stateTransition)
-        RootTournament(_initialHash, _tournamentParameters, _provider)
-    {}
+    using Clones for address;
+
+    struct Args {
+        TournamentArgs tournamentArgs;
+        IStateTransition stateTransition;
+    }
+
+    function _args() internal view returns (Args memory) {
+        return abi.decode(address(this).fetchCloneArgs(), (Args));
+    }
+
+    function _tournamentArgs()
+        internal
+        view
+        override
+        returns (TournamentArgs memory)
+    {
+        return _args().tournamentArgs;
+    }
+
+    function _stateTransition()
+        internal
+        view
+        override
+        returns (IStateTransition)
+    {
+        return _args().stateTransition;
+    }
 }

--- a/prt/contracts/src/tournament/concretes/TopTournament.sol
+++ b/prt/contracts/src/tournament/concretes/TopTournament.sol
@@ -3,23 +3,41 @@
 
 pragma solidity ^0.8.17;
 
+import {Clones} from "@openzeppelin-contracts-5.2.0/proxy/Clones.sol";
+
 import "prt-contracts/tournament/abstracts/NonLeafTournament.sol";
 import "prt-contracts/tournament/abstracts/RootTournament.sol";
 
 import "prt-contracts/tournament/factories/IMultiLevelTournamentFactory.sol";
 
-import "prt-contracts/types/TournamentParameters.sol";
-import "prt-contracts/types/Machine.sol";
-
 /// @notice Top tournament of a multi-level instance
 contract TopTournament is NonLeafTournament, RootTournament {
-    constructor(
-        Machine.Hash _initialHash,
-        TournamentParameters memory _tournamentParameters,
-        IDataProvider _provider,
-        IMultiLevelTournamentFactory _tournamentFactory
-    )
-        NonLeafTournament(_tournamentFactory)
-        RootTournament(_initialHash, _tournamentParameters, _provider)
-    {}
+    using Clones for address;
+
+    struct Args {
+        TournamentArgs tournamentArgs;
+        IMultiLevelTournamentFactory tournamentFactory;
+    }
+
+    function _args() internal view returns (Args memory) {
+        return abi.decode(address(this).fetchCloneArgs(), (Args));
+    }
+
+    function _tournamentArgs()
+        internal
+        view
+        override
+        returns (TournamentArgs memory)
+    {
+        return _args().tournamentArgs;
+    }
+
+    function _tournamentFactory()
+        internal
+        view
+        override
+        returns (IMultiLevelTournamentFactory)
+    {
+        return _args().tournamentFactory;
+    }
 }

--- a/prt/contracts/src/tournament/factories/multilevel/MiddleTournamentFactory.sol
+++ b/prt/contracts/src/tournament/factories/multilevel/MiddleTournamentFactory.sol
@@ -3,46 +3,61 @@
 
 pragma solidity ^0.8.17;
 
+import {Clones} from "@openzeppelin-contracts-5.2.0/proxy/Clones.sol";
+
 import "prt-contracts/tournament/abstracts/NonLeafTournament.sol";
 import "prt-contracts/tournament/concretes/MiddleTournament.sol";
-
-import "prt-contracts/types/TournamentParameters.sol";
 import "prt-contracts/tournament/factories/IMultiLevelTournamentFactory.sol";
-
-import "prt-contracts/types/Machine.sol";
-import "prt-contracts/types/Tree.sol";
 import "prt-contracts/tournament/libs/Time.sol";
+import "prt-contracts/types/Machine.sol";
+import "prt-contracts/types/TournamentParameters.sol";
+import "prt-contracts/types/Tree.sol";
 
 contract MiddleTournamentFactory {
-    constructor() {}
+    using Clones for address;
+
+    MiddleTournament immutable _impl;
+
+    constructor(MiddleTournament impl) {
+        _impl = impl;
+    }
 
     function instantiate(
-        Machine.Hash _initialHash,
-        Tree.Node _contestedCommitmentOne,
-        Machine.Hash _contestedFinalStateOne,
-        Tree.Node _contestedCommitmentTwo,
-        Machine.Hash _contestedFinalStateTwo,
-        Time.Duration _allowance,
-        uint256 _startCycle,
-        uint64 _level,
-        TournamentParameters memory _tournamentParameters,
-        IDataProvider _provider,
-        IMultiLevelTournamentFactory _tournamentFactory
+        Machine.Hash initialHash,
+        Tree.Node contestedCommitmentOne,
+        Machine.Hash contestedFinalStateOne,
+        Tree.Node contestedCommitmentTwo,
+        Machine.Hash contestedFinalStateTwo,
+        Time.Duration allowance,
+        uint256 startCycle,
+        uint64 level,
+        TournamentParameters memory tournamentParameters,
+        IDataProvider provider,
+        IMultiLevelTournamentFactory tournamentFactory
     ) external returns (MiddleTournament) {
-        MiddleTournament _tournament = new MiddleTournament(
-            _initialHash,
-            _contestedCommitmentOne,
-            _contestedFinalStateOne,
-            _contestedCommitmentTwo,
-            _contestedFinalStateTwo,
-            _allowance,
-            _startCycle,
-            _level,
-            _tournamentParameters,
-            _provider,
-            _tournamentFactory
-        );
-
-        return _tournament;
+        MiddleTournament.Args memory args = MiddleTournament.Args({
+            tournamentArgs: TournamentArgs({
+                initialHash: initialHash,
+                startCycle: startCycle,
+                level: level,
+                levels: tournamentParameters.levels,
+                log2step: tournamentParameters.log2step,
+                height: tournamentParameters.height,
+                startInstant: Time.currentTime(),
+                allowance: allowance,
+                maxAllowance: tournamentParameters.maxAllowance,
+                matchEffort: tournamentParameters.matchEffort,
+                provider: provider
+            }),
+            nonRootTournamentArgs: NonRootTournamentArgs({
+                contestedCommitmentOne: contestedCommitmentOne,
+                contestedFinalStateOne: contestedFinalStateOne,
+                contestedCommitmentTwo: contestedCommitmentTwo,
+                contestedFinalStateTwo: contestedFinalStateTwo
+            }),
+            tournamentFactory: tournamentFactory
+        });
+        address clone = address(_impl).cloneWithImmutableArgs(abi.encode(args));
+        return MiddleTournament(clone);
     }
 }

--- a/prt/contracts/src/tournament/factories/multilevel/TopTournamentFactory.sol
+++ b/prt/contracts/src/tournament/factories/multilevel/TopTournamentFactory.sol
@@ -3,23 +3,46 @@
 
 pragma solidity ^0.8.17;
 
-import "prt-contracts/tournament/concretes/TopTournament.sol";
+import {Clones} from "@openzeppelin-contracts-5.2.0/proxy/Clones.sol";
 
+import "prt-contracts/tournament/concretes/TopTournament.sol";
 import "prt-contracts/types/TournamentParameters.sol";
 
 contract TopTournamentFactory {
-    constructor() {}
+    using Clones for address;
+
+    uint64 constant START_CYCLE = 0;
+    uint64 constant LEVEL = 0;
+
+    TopTournament immutable _impl;
+
+    constructor(TopTournament impl) {
+        _impl = impl;
+    }
 
     function instantiate(
-        Machine.Hash _initialHash,
-        TournamentParameters memory _tournamentParameters,
-        IDataProvider _provider,
-        IMultiLevelTournamentFactory _tournamentFactory
+        Machine.Hash initialHash,
+        TournamentParameters memory tournamentParameters,
+        IDataProvider provider,
+        IMultiLevelTournamentFactory tournamentFactory
     ) external returns (TopTournament) {
-        TopTournament _tournament = new TopTournament(
-            _initialHash, _tournamentParameters, _provider, _tournamentFactory
-        );
-
-        return _tournament;
+        TopTournament.Args memory args = TopTournament.Args({
+            tournamentArgs: TournamentArgs({
+                initialHash: initialHash,
+                startCycle: START_CYCLE,
+                level: LEVEL,
+                levels: tournamentParameters.levels,
+                log2step: tournamentParameters.log2step,
+                height: tournamentParameters.height,
+                startInstant: Time.currentTime(),
+                allowance: tournamentParameters.maxAllowance,
+                maxAllowance: tournamentParameters.maxAllowance,
+                matchEffort: tournamentParameters.matchEffort,
+                provider: provider
+            }),
+            tournamentFactory: tournamentFactory
+        });
+        address clone = address(_impl).cloneWithImmutableArgs(abi.encode(args));
+        return TopTournament(clone);
     }
 }

--- a/prt/contracts/test/BottomTournament.t.sol
+++ b/prt/contracts/test/BottomTournament.t.sol
@@ -10,7 +10,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-import "forge-std/Test.sol";
+import "forge-std-1.9.6/src/Test.sol";
 
 import "./Util.sol";
 import "prt-contracts/tournament/factories/MultiLevelTournamentFactory.sol";

--- a/prt/contracts/test/Clock.t.sol
+++ b/prt/contracts/test/Clock.t.sol
@@ -10,7 +10,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-import "forge-std/Test.sol";
+import "forge-std-1.9.6/src/Test.sol";
 
 import "prt-contracts/tournament/libs/Clock.sol";
 

--- a/prt/contracts/test/Libs.t.sol
+++ b/prt/contracts/test/Libs.t.sol
@@ -10,7 +10,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-import "forge-std/Test.sol";
+import "forge-std-1.9.6/src/Test.sol";
 
 import "prt-contracts/types/Machine.sol";
 import "prt-contracts/tournament/libs/Time.sol";

--- a/prt/contracts/test/Match.t.sol
+++ b/prt/contracts/test/Match.t.sol
@@ -10,8 +10,8 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-import "forge-std/console.sol";
-import "forge-std/Test.sol";
+import "forge-std-1.9.6/src/console.sol";
+import "forge-std-1.9.6/src/Test.sol";
 
 import "prt-contracts/tournament/libs/Match.sol";
 import "prt-contracts/arbitration-config/CanonicalConstants.sol";

--- a/prt/contracts/test/MiddleTournament.t.sol
+++ b/prt/contracts/test/MiddleTournament.t.sol
@@ -10,7 +10,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-import "forge-std/Test.sol";
+import "forge-std-1.9.6/src/Test.sol";
 
 import "./Util.sol";
 import "prt-contracts/tournament/factories/MultiLevelTournamentFactory.sol";

--- a/prt/contracts/test/StateTransition.t.sol
+++ b/prt/contracts/test/StateTransition.t.sol
@@ -10,7 +10,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-import "forge-std/Test.sol";
+import "forge-std-1.9.6/src/Test.sol";
 
 import "./Util.sol";
 import "src/state-transition/CartesiStateTransition.sol";

--- a/prt/contracts/test/StateTransitionFfi.t.sol
+++ b/prt/contracts/test/StateTransitionFfi.t.sol
@@ -10,7 +10,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-import "forge-std/Test.sol";
+import "forge-std-1.9.6/src/Test.sol";
 
 import "./Util.sol";
 import "src/state-transition/CartesiStateTransition.sol";

--- a/prt/contracts/test/TopTournament.t.sol
+++ b/prt/contracts/test/TopTournament.t.sol
@@ -10,7 +10,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-import "forge-std/Test.sol";
+import "forge-std-1.9.6/src/Test.sol";
 
 import "./Util.sol";
 import "prt-contracts/tournament/factories/MultiLevelTournamentFactory.sol";

--- a/prt/contracts/test/Tournament.t.sol
+++ b/prt/contracts/test/Tournament.t.sol
@@ -10,8 +10,8 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-import "forge-std/console.sol";
-import "forge-std/Test.sol";
+import "forge-std-1.9.6/src/console.sol";
+import "forge-std-1.9.6/src/Test.sol";
 
 import "./Util.sol";
 import "prt-contracts/tournament/factories/MultiLevelTournamentFactory.sol";

--- a/prt/contracts/test/TournamentFactory.t.sol
+++ b/prt/contracts/test/TournamentFactory.t.sol
@@ -10,8 +10,8 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-import "forge-std/console.sol";
-import "forge-std/Test.sol";
+import "forge-std-1.9.6/src/console.sol";
+import "forge-std-1.9.6/src/Test.sol";
 
 import "prt-contracts/tournament/abstracts/RootTournament.sol";
 import "prt-contracts/tournament/factories/MultiLevelTournamentFactory.sol";

--- a/prt/contracts/test/Util.sol
+++ b/prt/contracts/test/Util.sol
@@ -255,14 +255,15 @@ contract Util {
         internal
         returns (SingleLevelTournamentFactory)
     {
+        (CartesiStateTransition stateTransition,,) =
+            instantiateStateTransition();
         SingleLevelTournamentFactory singleLevelFactory = new SingleLevelTournamentFactory(
-            ArbitrationConstants.MATCH_EFFORT,
-            ArbitrationConstants.MAX_ALLOWANCE,
+            new SingleLevelTournament(),
+            stateTransition,
             ArbitrationConstants.log2step(0),
             ArbitrationConstants.height(0),
-            new CartesiStateTransition(
-                new RiscVStateTransition(), new CmioStateTransition()
-            )
+            ArbitrationConstants.MAX_ALLOWANCE,
+            ArbitrationConstants.MATCH_EFFORT
         );
 
         return singleLevelFactory;
@@ -277,9 +278,9 @@ contract Util {
             instantiateStateTransition();
         return (
             new MultiLevelTournamentFactory(
-                new TopTournamentFactory(),
-                new MiddleTournamentFactory(),
-                new BottomTournamentFactory(),
+                new TopTournamentFactory(new TopTournament()),
+                new MiddleTournamentFactory(new MiddleTournament()),
+                new BottomTournamentFactory(new BottomTournament()),
                 new CanonicalTournamentParametersProvider(),
                 stateTransition
             ),

--- a/prt/contracts/test/Util.sol
+++ b/prt/contracts/test/Util.sol
@@ -10,7 +10,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-import "forge-std/console.sol";
+import "forge-std-1.9.6/src/console.sol";
 
 import "src/arbitration-config/CanonicalConstants.sol";
 import "src/arbitration-config/CanonicalTournamentParametersProvider.sol";


### PR DESCRIPTION
## Rationale

This PR makes the tournament factories instantiate [EIP-1167](https://eips.ethereum.org/EIPS/eip-1167) minimal proxies using OpenZeppelin's [`Clones`](https://docs.openzeppelin.com/contracts/5.x/api/proxy#Clones) library. The main motivation behind this change is to reduce the gas cost of tournament contract instantiation. This is possible by reducing the size of the deployed bytecode, as these minimal proxies are much smaller than the tournament contracts. They delegate every message call to an implementation contract, which holds the logic. Data is still stored in the proxy contract thanks to the [`DELEGATECALL`](https://www.evm.codes/?fork=cancun#f4) instruction.

## Clones and Immutable Arguments

Making tournament contracts "clonable" requires refactoring immutable state variables. In Solidity, when you annotate a state variable with the `immutable` keyword, the Solidity compiler will embed this variable in the contract bytecode, which is immutable by the design of the EVM. However, we do not want these variables to be embedded in the bytecode of the implementation contract. Rather, we want it to be embedded in the bytecode of the proxy contract, as different instances may hold different values for these immutable variables. This refactor is made intuitive thanks to OpenZeppelin's `Clones` library, which contains the functions `cloneWithImmutableArgs` (for clone factories) and `fetchCloneArgs` (for clones). The first function appends the minimal proxy bytecode with arbitrary byte arrays, which encode the immutable arguments. Meanwhile, the second function fetches these immutable arguments from the bytecode of the proxy contract through a combination of [`ADDRESS`](https://www.evm.codes/?fork=cancun#30), [`EXTCODESIZE`](https://www.evm.codes/?fork=cancun#3b), and [`EXTCODECOPY`](https://www.evm.codes/?fork=cancun#3c).

This refactoring is implemented in parts. First, we group all immutable variables of each abstract contract (root, non-root, leaf, non-leaf) into a structure and make it accessible via an internal view function (annotated as virtual). Then, we make the concrete contracts (bottom, middle, top, single-level) implement these virtual functions by fetching the clone arguments from the proxy contracts and decoding them. Finally, we make each factory receive an implementation contract on construction, and instantiate proxies that point to them, with the immutable arguments embedded in their bytecode.