### PR TITLE
feat: make `DaveConsensusFactory` a clone factory

### DIFF
--- a/cartesi-rollups/contracts/script/DaveConsensus.s.sol
+++ b/cartesi-rollups/contracts/script/DaveConsensus.s.sol
@@ -15,13 +15,14 @@ import "prt-contracts/../test/constants/TestTournamentParametersProvider.sol";
 import "cartesi-rollups-contracts-2.0.0/inputs/IInputBox.sol";
 
 import "src/DaveConsensus.sol";
+import "src/DaveConsensusFactory.sol";
 
 // Only used for tests
 contract DaveConsensusScript is Script {
     function run(Machine.Hash initialHash, IInputBox inputBox) external {
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
 
-        MultiLevelTournamentFactory factory = new MultiLevelTournamentFactory(
+        MultiLevelTournamentFactory tournamentFactory = new MultiLevelTournamentFactory(
             new TopTournamentFactory(new TopTournament()),
             new MiddleTournamentFactory(new MiddleTournament()),
             new BottomTournamentFactory(new BottomTournament()),
@@ -29,7 +30,10 @@ contract DaveConsensusScript is Script {
             new CartesiStateTransition(new RiscVStateTransition(), new CmioStateTransition())
         );
 
-        new DaveConsensus(inputBox, address(0x0), factory, initialHash);
+        DaveConsensusFactory daveConsensusFactory =
+            new DaveConsensusFactory(new DaveConsensus(), inputBox, tournamentFactory);
+
+        daveConsensusFactory.newDaveConsensus(address(0), initialHash);
 
         vm.stopBroadcast();
     }

--- a/cartesi-rollups/contracts/test/DaveConsensusFactory.t.sol
+++ b/cartesi-rollups/contracts/test/DaveConsensusFactory.t.sol
@@ -37,7 +37,7 @@ contract DaveConsensusFactoryTest is Test {
     function setUp() public {
         _inputBox = new InputBox();
         _tournamentFactory = new MockTournamentFactory();
-        _factory = new DaveConsensusFactory(_inputBox, _tournamentFactory);
+        _factory = new DaveConsensusFactory(new DaveConsensus(), _inputBox, _tournamentFactory);
         _initialMachineStateHash = Machine.Hash.wrap(0x0);
     }
 


### PR DESCRIPTION
# Gas report diff
_This report was generated by [gasdiff 0.4.0](https://pypi.org/project/gasdiff/0.4.0/)_

### DaveConsensus

| Metric | Before | After | Difference |
| - | - | - | - |
| Deployment gas | 1617611 | 1720719 | +103108 (6.4%) |
| Deployment size | 8041 | 7741 | -300 (-3.7%) |
| canSettle min | 1692 (768) | 1714 (768) | +22 (1.3%) |
| canSettle mean | 5692 (768) | 5714 (768) | +22 (0.4%) |
| canSettle median | 7692 (768) | 7714 (768) | +22 (0.3%) |
| canSettle max | 7692 (768) | 7714 (768) | +22 (0.3%) |
| getApplicationContract min | 310 (256) | 1584 (256) | +1274 (411.0%) |
| getApplicationContract mean | 310 (256) | 1584 (256) | +1274 (411.0%) |
| getApplicationContract median | 310 (256) | 1584 (256) | +1274 (411.0%) |
| getApplicationContract max | 310 (256) | 1584 (256) | +1274 (411.0%) |
| getInputBox min | 166 (256) | 1386 (256) | +1220 (734.9%) |
| getInputBox mean | 166 (256) | 1386 (256) | +1220 (734.9%) |
| getInputBox median | 166 (256) | 1386 (256) | +1220 (734.9%) |
| getInputBox max | 166 (256) | 1386 (256) | +1220 (734.9%) |
| getTournamentFactory min | 266 (256) | 1492 (256) | +1226 (460.9%) |
| getTournamentFactory mean | 266 (256) | 1492 (256) | +1226 (460.9%) |
| getTournamentFactory median | 266 (256) | 1492 (256) | +1226 (460.9%) |
| getTournamentFactory max | 266 (256) | 1492 (256) | +1226 (460.9%) |
| provideMerkleRootOfInput mean | 12635 (511) | 13321 (511) | +686 (5.4%) |
| provideMerkleRootOfInput max | 26942 (511) | 28318 (511) | +1376 (5.1%) |
| sealFirstEpoch min | 0 | 40001 (1281) | +40001 (inf%) |
| sealFirstEpoch mean | 0 | 146191 (1281) | +146191 (inf%) |
| sealFirstEpoch median | 0 | 206672 (1281) | +206672 (inf%) |
| sealFirstEpoch max | 0 | 206672 (1281) | +206672 (inf%) |
| settle min | 26636 (769) | 5072 (769) | -21564 (-81.0%) |
| settle mean | 105734 (769) | 74212 (769) | -31522 (-29.8%) |
| settle median | 36283 (769) | 14779 (769) | -21504 (-59.3%) |
| settle max | 267609 (769) | 216990 (769) | -50619 (-18.9%) |

### DaveConsensusFactory

| Metric | Before | After | Difference |
| - | - | - | - |
| Deployment gas | 1984495 | 339531 | -1644964 (-82.9%) |
| Deployment size | 8965 | 1629 | -7336 (-81.8%) |
| calculateDaveConsensusAddress min | 6385 (512) | 1469 (768) | -4916 (-77.0%) |
| calculateDaveConsensusAddress mean | 8385 (512) | 1469 (768) | -6916 (-82.5%) |
| calculateDaveConsensusAddress median | 8385 (512) | 1469 (768) | -6916 (-82.5%) |
| calculateDaveConsensusAddress max | 10385 (512) | 1469 (768) | -8916 (-85.9%) |
| newDaveConsensus(address,bytes32) min | 1521172 (256) | 133470 (256) | -1387702 (-91.2%) |
| newDaveConsensus(address,bytes32) mean | 1539438 (256) | 151888 (256) | -1387550 (-90.1%) |
| newDaveConsensus(address,bytes32) median | 1541300 (256) | 153598 (256) | -1387702 (-90.0%) |
| newDaveConsensus(address,bytes32) max | 1541300 (256) | 153598 (256) | -1387702 (-90.0%) |
| newDaveConsensus(address,bytes32,bytes32) min | 1522838 (512) | 133667 (1281) | -1389171 (-91.2%) |
| newDaveConsensus(address,bytes32,bytes32) mean | 520049203 (512) | 208032133 (1281) | -312017070 (-60.0%) |
| newDaveConsensus(address,bytes32,bytes32) median | 519911910 (512) | 301298 (1281) | -519610612 (-99.9%) |
| newDaveConsensus(address,bytes32,bytes32) max | 1038885023 (512) | 1040245464 (1281) | +1360441 (0.1%) |