### PR TITLE
feat: Cannonfile for deploying application to production

### DIFF
--- a/cartesi-rollups/contracts/README.md
+++ b/cartesi-rollups/contracts/README.md
@@ -1,0 +1,86 @@
+# Contracts for Dave PRT in Cartesi Rollups
+
+This project focuses on supporting Dave PRT as a settlement module for Cartesi Rollups.
+The main contract is the `DaveConsensus` contract, which implements the `IOutputsMerkleRootValidator` interface.
+This contract instantiates a PRT tournament every epoch to settle on the new state of the machine.
+
+## Features
+
+- Integrates Dave PRT with Cartesi Rollups
+- Contains a factory contract for `DaveConsensus` contracts
+- Unit tests in Solidity using Forge
+- Cannonfile for modular deployments
+
+## Installing dependencies
+
+In order to install the Node.js and Solidity dependencies, please run the following command.
+
+```sh
+just install-deps
+```
+
+## Building
+
+In order to compile the contracts and generate Rust bindings, you may run the following command.
+
+```sh
+just build
+```
+
+## Testing
+
+You can run the unit tests with the following command.
+
+```sh
+just test
+```
+
+## Deploying an application
+
+Besides the `DaveConsensusFactory` contract,
+you may also want to deploy an application contract
+that is validated by a `DaveConsensus` contract.
+In order to do so, you need to first build your application machine
+and compute its initial hash (also known as its _template hash_).
+Depending on whether you wish to deploy this application
+to a local, development network (like `anvil` or `reth`)
+or to a live production network (like a mainnet or a testnet),
+there are different sets of commands you may want to run.
+Nevertheless, they all share the same options and environment variables:
+
+| Option | Description | Environment variable |
+| :-: | :-: | :- |
+| `--rpc-url <URL>` | RPC URL | `CANNON_RPC_URL` |
+| `--private-key <PK>` | Private key | `CANNON_PRIVATE_KEY` |
+| `--write-deployments <DIR>` | Deployments diretory | |
+| `--dry-run` | Simulate deployment on a local fork | |
+| `--impersonate <ADDR>` | Impersonate address (requires `--dry-run`) | |
+| `--impersonate-all` | Impersonate all addresses (requires `--dry-run`) | |
+
+### Local deployment (dev)
+
+In order to deploy the contracts to a local development network (e.g. Anvil), you may run the following command.
+This command receives a positional argument, the initial machine state hash of the application.
+
+```sh
+just deploy-instance-dev $INITIAL_HASH
+```
+
+Additional arguments are forwarded to the [`cannon build`](https://usecannon.com/learn/cli#build) command.
+
+### Live deployment (prod)
+
+Deploying the contracts to a production network is also simple to do through the following command.
+This command takes the same positional argument as the development-mode variant.
+
+```sh
+just deploy-instance $INITIAL_HASH
+```
+
+If, instead, you wish to deploy just the core contracts, you can run the following command.
+
+```sh
+just deploy-core
+```
+
+Both commands require an RPC URL and private key to be specified, or may be simulated through a dry run.

--- a/cartesi-rollups/contracts/cannonfile.dev-instance.toml
+++ b/cartesi-rollups/contracts/cannonfile.dev-instance.toml
@@ -1,6 +1,6 @@
-name = 'cartesi-dave-consensus-instance'
+name = 'cartesi-dave-consensus-dev'
 version = '0.0.1'
-description = 'Cartesi Dave Consensus Instance'
+description = 'Cartesi Dave Consensus (dev)'
 
 [var.Settings]
 appOwner = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"

--- a/cartesi-rollups/contracts/cannonfile.prod-instance.toml
+++ b/cartesi-rollups/contracts/cannonfile.prod-instance.toml
@@ -1,0 +1,55 @@
+name = 'cartesi-dave-consensus-prod'
+version = '0.0.1'
+description = 'Cartesi Dave Consensus (prod)'
+
+[var.Settings]
+appOwner = "<%= zeroAddress %>"
+initialHash = "<%= zeroHash %>"
+
+[pull.cartesiRollups]
+source = "cartesi-rollups:2.0.0-rc.18@main"
+
+[pull.prtContracts]
+source = "cartesi-prt-multilevel:0.1.0-rc.4@main"
+
+[pull.daveConsensusFactory]
+source = "cartesi-dave-consensus-factory:0.1.0-rc.4@main"
+
+[invoke.newApplication]
+target = "cartesiRollups.ApplicationFactory"
+func = "newApplication(address,address,bytes32,bytes)"
+args = [
+    "<%= zeroAddress %>",
+    "<%= settings.appOwner %>",
+    "<%= settings.initialHash %>",
+    "<%= concat([slice(keccak256('InputBox(address)'), 0, 4), pad(cartesiRollups.InputBox.address)]) %>"
+]
+factory.ApplicationInstance.artifact = "Application"
+factory.ApplicationInstance.event = "ApplicationCreated"
+factory.ApplicationInstance.arg = 4
+
+[invoke.newDaveConsensus]
+target = "daveConsensusFactory.DaveConsensusFactory"
+func = "newDaveConsensus(address,bytes32)"
+args = [
+    "<%= contracts.ApplicationInstance.address %>",
+    "<%= settings.initialHash %>",
+]
+factory.DaveConsensusInstance.artifact = "DaveConsensus"
+factory.DaveConsensusInstance.event = "DaveConsensusCreated"
+factory.DaveConsensusInstance.arg = 0
+depends = ["invoke.newApplication"]
+
+[invoke.migrateToOutputsMerkleRootValidator]
+target = "ApplicationInstance"
+func = "migrateToOutputsMerkleRootValidator"
+args = ["<%= contracts.DaveConsensusInstance.address %>"]
+from = "<%= settings.appOwner %>"
+depends = ["invoke.newApplication", "invoke.newDaveConsensus"]
+
+[invoke.renounceOwnership]
+target = "ApplicationInstance"
+func = "renounceOwnership"
+args = []
+from = "<%= settings.appOwner %>"
+depends = ["invoke.migrateToOutputsMerkleRootValidator"]

--- a/cartesi-rollups/contracts/justfile
+++ b/cartesi-rollups/contracts/justfile
@@ -4,9 +4,8 @@ DEPLOYMENTS_DIR := "./deployments"
 SRC_DIR := "."
 BINDINGS_FILTER := "DaveConsensus"
 
-export PRIVATE_KEY := "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-ANVIL_ENDPOINT := "http://127.0.0.1:8545"
-ANVIL_CHAIN_ID := "31337"
+DEVNET_PRIVATE_KEY := "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+DEVNET_RPC_URL := "http://127.0.0.1:8545"
 
 default: build
 
@@ -48,18 +47,30 @@ bind: clean-bindings
         --module --bindings-path {{BINDINGS_DIR}} \
         --root {{SRC_DIR}}
 
-deploy-dev INITIAL_HASH: deploy-prt-core (deploy-instance INITIAL_HASH)
+deploy-core *OPTS: \
+        (deploy-prt-core OPTS) \
+        (deploy "cannonfile.toml" OPTS)
 
-deploy-prt-core:
-    just -f ../../prt/contracts/justfile deploy-core
+deploy-instance INITIAL_HASH *OPTS: \
+        (deploy-prt-core OPTS) \
+        (deploy-core OPTS) \
+        (deploy "cannonfile.prod-instance.toml" ("initialHash=" + INITIAL_HASH) OPTS)
 
-deploy-instance INITIAL_HASH: deploy-prt-core (deploy "cannonfile.instance.toml" ("initialHash=" + INITIAL_HASH))
+deploy-instance-dev INITIAL_HASH *OPTS: \
+        (deploy-prt-core-dev OPTS) \
+        (deploy-dev "cannonfile.dev-instance.toml" ("initialHash=" + INITIAL_HASH) OPTS)
 
-deploy CANNONFILE *SETTINGS:
-    pnpm cannon build \
-        --wipe \
-        --rpc-url {{ANVIL_ENDPOINT}} \
-        --private-key {{PRIVATE_KEY}} \
-        --write-deployments {{DEPLOYMENTS_DIR}} \
-        {{CANNONFILE}} \
-        {{SETTINGS}}
+deploy-prt-core *OPTS:
+    just -f ../../prt/contracts/justfile deploy-core {{OPTS}}
+
+deploy-prt-core-dev *OPTS:
+    just -f ../../prt/contracts/justfile deploy-core-dev {{OPTS}}
+
+deploy-dev CANNONFILE *OPTS: \
+        (deploy CANNONFILE OPTS \
+            "--wipe" \
+            "--rpc-url" DEVNET_RPC_URL \
+            "--private-key" DEVNET_PRIVATE_KEY)
+
+deploy CANNONFILE *OPTS:
+    pnpm cannon build {{CANNONFILE}} {{OPTS}}

--- a/prt/contracts/cannonfile.dev-instance.toml
+++ b/prt/contracts/cannonfile.dev-instance.toml
@@ -1,6 +1,6 @@
-name = 'cartesi-prt-multilevel-instance'
+name = 'cartesi-prt-multilevel-dev'
 version = '0.0.1'
-description = 'Cartesi PRT contracts test'
+description = 'Cartesi PRT contracts (dev)'
 
 [pull.prtContracts]
 source = "cartesi-prt-multilevel:0.0.1@main"

--- a/prt/contracts/justfile
+++ b/prt/contracts/justfile
@@ -3,9 +3,8 @@ DEPLOYMENTS_DIR := "./deployments"
 SRC_DIR := "."
 BINDINGS_FILTER := "^[^I].+TournamentFactory|LeafTournament|RootTournament|^Tournament$"
 
-export PRIVATE_KEY := "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-ANVIL_ENDPOINT := "http://127.0.0.1:8545"
-ANVIL_CHAIN_ID := "31337"
+DEVNET_PRIVATE_KEY := "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+DEVNET_RPC_URL := "http://127.0.0.1:8545"
 
 default: build
 
@@ -46,17 +45,21 @@ bind: clean-bindings
     --module --bindings-path {{BINDINGS_DIR}} \
     --root {{SRC_DIR}}
 
-deploy-dev INITIAL_HASH: deploy-core (deploy-instance INITIAL_HASH)
+deploy-core *OPTS: \
+        (deploy "cannonfile.toml" OPTS)
 
-deploy-core: (deploy "cannonfile.toml")
+deploy-core-dev *OPTS: \
+        (deploy-dev "cannonfile.toml" OPTS)
 
-deploy-instance INITIAL_HASH: deploy-core (deploy "cannonfile.instance.toml" ("initialHash=" + INITIAL_HASH))
+deploy-instance-dev INITIAL_HASH *OPTS: \
+        (deploy-core-dev OPTS) \
+        (deploy-dev "cannonfile.dev-instance.toml" ("initialHash=" + INITIAL_HASH) OPTS)
 
-deploy CANNONFILE *SETTINGS:
-    pnpm cannon build \
-        --wipe \
-        --rpc-url {{ANVIL_ENDPOINT}} \
-        --private-key {{PRIVATE_KEY}} \
-        --write-deployments {{DEPLOYMENTS_DIR}} \
-        {{CANNONFILE}} \
-        {{SETTINGS}}
+deploy-dev CANNONFILE *OPTS: \
+        (deploy CANNONFILE OPTS \
+            "--wipe" \
+            "--rpc-url" DEVNET_RPC_URL \
+            "--private-key" DEVNET_PRIVATE_KEY)
+
+deploy CANNONFILE *OPTS:
+    pnpm cannon build {{CANNONFILE}} {{OPTS}}

--- a/prt/tests/compute/programs/build_anvil_state.sh
+++ b/prt/tests/compute/programs/build_anvil_state.sh
@@ -25,13 +25,19 @@ sleep 5
 
 # deploy smart contracts
 initial_hash=0x`xxd -p -c32 "${program_path}/machine-image/hash"`
-just -f ../../../contracts/justfile deploy-dev $initial_hash
+contracts_dir=../../../contracts
+deployments_dir=deployments/dev-$initial_hash
+just -f $contracts_dir/justfile deploy-instance-dev $initial_hash --write-deployments $deployments_dir
 
 
 # generate address file
 rm -f $program_path/addresses
 
-jq -r '.address' ../../../contracts/deployments/TopTournamentInstance.json >> $program_path/addresses
+getaddress() {
+    jq -r '.address' "$contracts_dir/$deployments_dir/$1.json"
+}
+
+getaddress TopTournamentInstance >> $program_path/addresses
 
 cast rpc anvil_mine 2
 

--- a/test/programs/build_anvil_state.sh
+++ b/test/programs/build_anvil_state.sh
@@ -25,15 +25,21 @@ sleep 5
 
 # deploy smart contracts
 initial_hash=0x`xxd -p -c32 "${program_path}/machine-image/hash"`
-just -f ../../cartesi-rollups/contracts/justfile deploy-dev $initial_hash
+contracts_dir=../../cartesi-rollups/contracts
+deployments_dir=deployments/dev-$initial_hash
+just -f $contracts_dir/justfile deploy-instance-dev $initial_hash --write-deployments $deployments_dir
 
 
 # generate address file
 rm -f $program_path/addresses
 
-jq -r '.address' ../../cartesi-rollups/contracts/deployments/InputBox.json >> $program_path/addresses
-jq -r '.address' ../../cartesi-rollups/contracts/deployments/DaveConsensusInstance.json >> $program_path/addresses
-jq -r '.address' ../../cartesi-rollups/contracts/deployments/ApplicationInstance.json >> $program_path/addresses
+getaddress() {
+    jq -r '.address' "$contracts_dir/$deployments_dir/$1.json"
+}
+
+getaddress InputBox >> $program_path/addresses
+getaddress DaveConsensusInstance >> $program_path/addresses
+getaddress ApplicationInstance >> $program_path/addresses
 
 cast rpc anvil_mine 2
 


### PR DESCRIPTION
This PR's main contribution is a Cannonfile for deploying an `Application` contract validated by a `DaveConsensus` contract. Besides this main goal, this PR also:

- Adds a `README.md` explaining how to use this Cannonfile
- Refactors the Justfiles to avoid code duplication
- Adjusts the `build_anvil_state.sh` Shell scripts used in tests
- Renames the devnet Cannonfiles to avoid confusion