### PR TITLE
fix: pass `--skip-extra-derives` to `forge bind`

### DIFF
--- a/cartesi-rollups/contracts/justfile
+++ b/cartesi-rollups/contracts/justfile
@@ -45,6 +45,7 @@ clean-deployments:
 bind: clean-bindings
     forge bind --alloy --select {{BINDINGS_FILTER}} \
         --module --bindings-path {{BINDINGS_DIR}} \
+        --skip-extra-derives \
         --root {{SRC_DIR}}
 
 deploy-core *OPTS: \

--- a/prt/contracts/justfile
+++ b/prt/contracts/justfile
@@ -43,6 +43,7 @@ clean-deployments:
 bind: clean-bindings
     forge bind --alloy --select "{{BINDINGS_FILTER}}" \
     --module --bindings-path {{BINDINGS_DIR}} \
+    --skip-extra-derives \
     --root {{SRC_DIR}}
 
 deploy-core *OPTS: \


### PR DESCRIPTION
Closes #172