### PR TITLE
feat: add `getDeploymentBlockNumber` view function to `DaveConsensus`

### DIFF
--- a/cartesi-rollups/contracts/src/DaveConsensus.sol
+++ b/cartesi-rollups/contracts/src/DaveConsensus.sol
@@ -58,6 +58,9 @@ contract DaveConsensus is IDataProvider, IOutputsMerkleRootValidator, ERC165 {
     /// @notice The contract used to instantiate tournaments
     ITournamentFactory immutable _tournamentFactory;
 
+    /// @notice Deployment block number
+    uint256 immutable _deploymentBlockNumber = block.number;
+
     /// @notice Current sealed epoch number
     uint256 _epochNumber;
 
@@ -242,6 +245,10 @@ contract DaveConsensus is IDataProvider, IOutputsMerkleRootValidator, ERC165 {
     function supportsInterface(bytes4 interfaceId) public view override(IERC165, ERC165) returns (bool) {
         return interfaceId == type(IDataProvider).interfaceId
             || interfaceId == type(IOutputsMerkleRootValidator).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    function getDeploymentBlockNumber() external view returns (uint256) {
+        return _deploymentBlockNumber;
     }
 
     function _validateOutputTree(

--- a/cartesi-rollups/contracts/test/DaveConsensus.t.sol
+++ b/cartesi-rollups/contracts/test/DaveConsensus.t.sol
@@ -147,8 +147,11 @@ contract DaveConsensusTest is Test {
         bytes32[3] calldata outputsMerkleRoots,
         uint256[2] memory inputCounts,
         bytes32[3] calldata salts,
-        Tree.Node[2] calldata winnerCommitments
+        Tree.Node[2] calldata winnerCommitments,
+        uint256 deploymentBlockNumber
     ) external {
+        vm.roll(deploymentBlockNumber);
+
         for (uint256 i; i < 2; ++i) {
             inputCounts[i] = bound(inputCounts[i], 0, 5);
         }
@@ -174,6 +177,7 @@ contract DaveConsensusTest is Test {
         assertEq(address(daveConsensus.getInputBox()), address(_inputBox));
         assertEq(daveConsensus.getApplicationContract(), appContract);
         assertEq(address(daveConsensus.getTournamentFactory()), address(_mockTournamentFactory));
+        assertEq(daveConsensus.getDeploymentBlockNumber(), deploymentBlockNumber);
 
         {
             bool isFinished;


### PR DESCRIPTION
Currently, the Rollups blockchain reader binary searches the deployment block of both the `InputBox` and `DaveConsensus` contracts. The deployment block of the `InputBox` could already be queried through the `getDeploymentBlockNumber` view function already present in it ([source](https://github.com/cartesi/rollups-contracts/blob/v2.0.0/src/inputs/IInputBox.sol#L46-L47)). This PR adds a similar function to `DaveConsensus`.