### PR TITLE
Fix Typos in Documentation for Contracts and Node

### DIFF
--- a/cartesi-rollups/contracts/README.md
+++ b/cartesi-rollups/contracts/README.md
@@ -52,7 +52,7 @@ Nevertheless, they all share the same options and environment variables:
 | :-: | :-: | :- |
 | `--rpc-url <URL>` | RPC URL | `CANNON_RPC_URL` |
 | `--private-key <PK>` | Private key | `CANNON_PRIVATE_KEY` |
-| `--write-deployments <DIR>` | Deployments diretory | |
+| `--write-deployments <DIR>` | Deployments directory | |
 | `--dry-run` | Simulate deployment on a local fork | |
 | `--impersonate <ADDR>` | Impersonate address (requires `--dry-run`) | |
 | `--impersonate-all` | Impersonate all addresses (requires `--dry-run`) | |

--- a/cartesi-rollups/node/README.md
+++ b/cartesi-rollups/node/README.md
@@ -29,7 +29,7 @@ Commands:
 
 Options:
       --app-address <APP_ADDRESS>
-          addresss of application [env: APP_ADDRESS=]
+          address of application [env: APP_ADDRESS=]
       --machine-path <MACHINE_PATH>
           path to machine template image [env: MACHINE_PATH=]
       --web3-rpc-url <WEB3_RPC_URL>


### PR DESCRIPTION

**Description:**  
This pull request corrects minor spelling errors in the documentation:
- Fixes "diretory" to "directory" in `cartesi-rollups/contracts/README.md`.
- Fixes "addresss" to "address" in `cartesi-rollups/node/README.md`.

