### PR TITLE
fix: use pinned Foundry version on node CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,24 +195,10 @@ jobs:
           apt-get install -y --no-install-recommends \
             g++-aarch64-linux-gnu
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
         with:
-          version: stable
-
-      - name: Install just
-        uses: extractions/setup-just@v3
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          package_json_file: 'prt/contracts/package.json'
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
-          cache-dependency-path: 'prt/contracts/pnpm-lock.yaml'
+          target: ${{ matrix.target }}
 
       - name: Contracts
         run: |


### PR DESCRIPTION
This PR fixes a bug in the build workflow file that caused the (now-deleted) v2 node build job to [fail](https://github.com/cartesi/dave/actions/runs/19129423157/job/54666334162).
The problem is that this job is not using the pinned Foundry version (currently, 1.4.3).
Instead, it is using the latest stable release of Foundry (currently, 1.4.4).
Despite the "stable" tag, Foundry is notoriously unstable.
In the case of Foundry 1.4.4, there is an issue in Forge that causes certain nested imports to fail.
You can read more about the bug here: https://github.com/foundry-rs/foundry/issues/12403
The bug has been fixed on nightly and should be released in an upcoming Foundry 1.5.0 release.
For the time being, we should use this pinned Foundry version (1.4.3) for all builds.

Once this PR is merged, we should release an RC to test the workflow changes.