### PR TITLE
Perform partial setup on node build CI job

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -5,11 +5,11 @@ inputs:
     description: 'Architecture to build for (if Rust is setup)'
     required: false
     default: 'x86_64-unknown-linux-gnu'
-  rust_version:
+  rust-version:
     description: 'Rust version to install (if Rust is setup)'
     required: false
     default: '1.86'
-  foundry_version:
+  foundry-version:
     description: 'Foundry version to install'
     required: false
     default: 'v1.4.3'
@@ -22,9 +22,9 @@ inputs:
     required: false
     default: 'true'
 outputs:
-  foundry-version:
+  installed-foundry-version:
     description: 'The version of Foundry that was installed'
-    value: ${{ steps.set-foundry-version.outputs.foundry-version }}
+    value: ${{ steps.set-foundry-version.outputs.version }}
 runs:
   using: composite
   steps:
@@ -38,7 +38,7 @@ runs:
       with:
         components: rustfmt
         target: ${{ inputs.target }}
-        toolchain: ${{ inputs.rust_version }}
+        toolchain: ${{ inputs.rust-version }}
         cache-on-failure: false
         cache-bin: false
 
@@ -46,12 +46,12 @@ runs:
       id: set-foundry-version
       shell: bash
       run: |
-        echo "foundry-version=${{ inputs.foundry_version }}" >> $GITHUB_OUTPUT
+        echo "version=${{ inputs.foundry-version }}" >> $GITHUB_OUTPUT
 
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
-        version: ${{ steps.set-foundry-version.outputs.foundry-version }}
+        version: ${{ steps.set-foundry-version.outputs.version }}
 
     - name: Install just
       uses: extractions/setup-just@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,7 +301,7 @@ jobs:
       - name: Compress devnet artifacts
         run: tar -czf "$FILEPATH" -C cartesi-rollups/contracts deployments state.json
         env:
-          FILEPATH: upload/cartesi-rollups-prt-anvil-${{ steps.setup.outputs.foundry-version }}.tar.gz
+          FILEPATH: upload/cartesi-rollups-prt-anvil-${{ steps.setup.outputs.installed-foundry-version }}.tar.gz
 
       - name: Upload files to GitHub Releases
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This PR makes the node build CI job skip QEMU and Rust setup steps.
These steps might be problematic because the node build CI job runs on the `rust` image.
Under this image, [the QEMU setup fails](https://github.com/cartesi/dave/actions/runs/19134533939/job/54683172572#step:6:32).
Moreover, the Rust setup step is not necessary, given that Rust is already setup.
This PR also adopts `kebab-case` for action inputs, which is the standard.