### PR TITLE
fix: improve leaf index validation

### DIFF
--- a/cartesi-rollups/contracts/src/Merkle.sol
+++ b/cartesi-rollups/contracts/src/Merkle.sol
@@ -142,7 +142,7 @@ library Merkle {
     /// @dev See `MerkleConstants` for leaf size.
     function getHashOfLeafAtIndex(bytes calldata data, uint256 leafIndex) internal pure returns (bytes32) {
         uint256 start = leafIndex << MerkleConstants.LOG2_LEAF_SIZE;
-        if (start < data.length) {
+        if (start < data.length && (start >> MerkleConstants.LOG2_LEAF_SIZE) == leafIndex) {
             /// forge-lint: disable-next-line(asm-keccak256)
             return keccak256(abi.encode(bytes32(data[start:])));
         } else {

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -8,7 +8,7 @@ RUN <<EOF
 set -eu
 apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git
 curl -L https://foundry.paradigm.xyz | bash
-~/.foundry/bin/foundryup --install v1.4.0
+~/.foundry/bin/foundryup --install v1.5.0
 install -Dm755 ~/.foundry/bin/* /usr/local/bin/
 EOF
 # cargo binstall (to install just)


### PR DESCRIPTION
With the stronger fuzzer introduced in Foundry v1.5.0, a new failing fuzz case was detected in:

```Merkle.getHashOfLeafAtIndex(bytes calldata data, uint256 leafIndex)```

The issue is caused by this line:

```uint256 start = leafIndex << MerkleConstants.LOG2_LEAF_SIZE;```

For very large leafIndex values, this shift can silently wrap around modulo `2^256`, making start small again. This may cause the condition start < data.length to incorrectly pass, leading to an invalid hash being returned instead of the pristine leaf.

Although this does not affect deployed contracts (where leafIndex is safely bounded), it breaks fuzz tests on Foundry v1.5.0.

This PR adds a reversible shift check to prevent wrap-around:

`if (start < data.length && (start >> MerkleConstants.LOG2_LEAF_SIZE) == leafIndex)`

This guarantees that the shift did not overflow and restores correct behavior under fuzzing.