### PR TITLE
fix: check SHA-256 hash of release artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,8 +138,10 @@ jobs:
         working-directory: ./machine/emulator
         run: |
           make bundle-boost
-          wget https://github.com/cartesi/machine-emulator/releases/download/v0.19.0/add-generated-files.diff
+          wget -O add-generated-files.diff https://github.com/cartesi/machine-emulator/releases/download/v0.19.0/add-generated-files.diff
+          echo "a892e2d9f5c331f5e80bcb5db4133e7db625aa4d14ffdf9467b75c4c34d1744f add-generated-files.diff" | sha256sum -c
           git apply add-generated-files.diff
+          rm add-generated-files.diff
           make
           sudo make install
 

--- a/justfile
+++ b/justfile
@@ -1,10 +1,12 @@
 update-submodules:
   git submodule update --recursive --init
 
-apply-generated-files-diff VERSION="v0.19.0":
+apply-generated-files-diff VERSION="v0.19.0" FILEHASH="a892e2d9f5c331f5e80bcb5db4133e7db625aa4d14ffdf9467b75c4c34d1744f":
   cd machine/emulator && \
-    wget https://github.com/cartesi/machine-emulator/releases/download/{{VERSION}}/add-generated-files.diff && \
-    git apply add-generated-files.diff
+    (wget -O add-generated-files.diff https://github.com/cartesi/machine-emulator/releases/download/{{VERSION}}/add-generated-files.diff && \
+    (echo "{{FILEHASH}} add-generated-files.diff" | sha256sum -c) && \
+    git apply add-generated-files.diff) ; \
+    rm -f add-generated-files.diff
 
 bundle-boost:
   make -C machine/emulator bundle-boost


### PR DESCRIPTION
It's good practice to check the hash of a downloaded file, to avoid supply-chain attacks.
Besides this change, this PR also:

- Forces `wget` to write the file to `add-generated-files.diff` by passing the `-O` option. Without such option, `wget` may avoid writing over `add-generated-files.diff` and instead write to `add-generated-files.diff.SUFFIX` where `SUFFIX` is some suffix added by `wget` to avoid collision with an already-existing file.

- Removes the `add-generated-files.diff` file after applying it. This ensures the Git submodule at `machine/emulator` stays clean after the repository is setup.