### PR TITLE
chore: bump rollups-contracts from 2.1.1 to 2.2.0

### DIFF
--- a/cartesi-rollups/contracts/foundry.toml
+++ b/cartesi-rollups/contracts/foundry.toml
@@ -8,9 +8,9 @@ via_ir = true
 
 allow_paths = ["../../prt/contracts", "../../machine/step"]
 remappings = [
-    "@openzeppelin-contracts-5.2.0/=dependencies/cartesi-rollups-contracts-2.1.1/dependencies/@openzeppelin-contracts-5.2.0/",
+    "@openzeppelin-contracts-5.2.0/=dependencies/cartesi-rollups-contracts-2.2.0/dependencies/@openzeppelin-contracts-5.2.0/",
     "@openzeppelin-contracts-5.5.0/=dependencies/@openzeppelin-contracts-5.5.0/",
-    "cartesi-rollups-contracts-2.1.1/=dependencies/cartesi-rollups-contracts-2.1.1/",
+    "cartesi-rollups-contracts-2.2.0/=dependencies/cartesi-rollups-contracts-2.2.0/",
     "forge-std-1.9.6/=dependencies/forge-std-1.9.6/",
     "prt-contracts/=../../prt/contracts/src/",
     "step/=../../machine/step/",
@@ -20,7 +20,7 @@ solc_version = "0.8.30"
 evm_version = "prague"
 fs_permissions = [
     { access = "read-write", path = "deployments" },
-    { access = "read", path = "dependencies/cartesi-rollups-contracts-2.1.1/deployments" },
+    { access = "read", path = "dependencies/cartesi-rollups-contracts-2.2.0/deployments" },
     { access = "read", path = "../../prt/contracts/deployments" },
 ]
 
@@ -37,4 +37,4 @@ exclude_lints = ["incorrect-shift"]
 [dependencies]
 "@openzeppelin-contracts" = "5.5.0"
 forge-std = "1.9.6"
-cartesi-rollups-contracts = "2.1.1"
+cartesi-rollups-contracts = "2.2.0"

--- a/cartesi-rollups/contracts/script/Deployment.s.sol
+++ b/cartesi-rollups/contracts/script/Deployment.s.sol
@@ -13,7 +13,7 @@ import {TestNonFungibleToken} from "src/TestNonFungibleToken.sol";
 contract DeploymentScript is BaseDeploymentScript {
     function run() external {
         _importDeployments("../../prt/contracts");
-        _importDeployments("dependencies/cartesi-rollups-contracts-2.1.1");
+        _importDeployments("dependencies/cartesi-rollups-contracts-2.2.0");
 
         address inputBox = _loadDeployment(".", "InputBox");
         address appFactory = _loadDeployment(".", "ApplicationFactory");

--- a/cartesi-rollups/contracts/script/deploy.sh
+++ b/cartesi-rollups/contracts/script/deploy.sh
@@ -6,7 +6,7 @@ cd "${BASH_SOURCE%/*}/.."
 
 roots=(
     '../../prt/contracts'
-    'dependencies/cartesi-rollups-contracts-2.1.1'
+    'dependencies/cartesi-rollups-contracts-2.2.0'
     '.'
 )
 

--- a/cartesi-rollups/contracts/soldeer.lock
+++ b/cartesi-rollups/contracts/soldeer.lock
@@ -7,10 +7,10 @@ integrity = "da8336cf949f0e0667ae8360af849681e3a3e76d7e61e7a86b1a3414a158aeea"
 
 [[dependencies]]
 name = "cartesi-rollups-contracts"
-version = "2.1.1"
-url = "https://soldeer-revisions.s3.amazonaws.com/cartesi-rollups-contracts/2_1_1_01-12-2025_17:36:49_rollups-contracts.zip"
-checksum = "96dc4fe4b1a91005bdb8fadf5f63bed6fec12b3b0da067aa539943f7e10a74be"
-integrity = "32cab9811c5f5380661fe9d2c043570c0b8656cd132043b76b9413c88c715164"
+version = "2.2.0"
+url = "https://soldeer-revisions.s3.amazonaws.com/cartesi-rollups-contracts/2_2_0_06-02-2026_19:12:57_rollups-contracts.zip"
+checksum = "8ec1e639104f544cfb198629cb258c54cfe86382fbc8402ca3e831406887fa08"
+integrity = "8af3eb0d2bdfe558ae0260562c617ff5aa79b687f584bc6687fdaedd93da3a02"
 
 [[dependencies]]
 name = "forge-std"

--- a/cartesi-rollups/contracts/src/CannonDependencies.sol
+++ b/cartesi-rollups/contracts/src/CannonDependencies.sol
@@ -6,4 +6,4 @@ pragma solidity ^0.8.0;
 // List of contracts used in Cannonfiles
 
 /// forge-lint: disable-next-line(unused-import)
-import {ApplicationFactory} from "cartesi-rollups-contracts-2.1.1/src/dapp/ApplicationFactory.sol";
+import {ApplicationFactory} from "cartesi-rollups-contracts-2.2.0/src/dapp/ApplicationFactory.sol";

--- a/cartesi-rollups/contracts/src/DaveAppFactory.sol
+++ b/cartesi-rollups/contracts/src/DaveAppFactory.sol
@@ -5,13 +5,13 @@ pragma solidity ^0.8.8;
 
 import {Create2} from "@openzeppelin-contracts-5.5.0/utils/Create2.sol";
 
-import {DataAvailability} from "cartesi-rollups-contracts-2.1.1/src/common/DataAvailability.sol";
+import {DataAvailability} from "cartesi-rollups-contracts-2.2.0/src/common/DataAvailability.sol";
 import {
     IOutputsMerkleRootValidator
-} from "cartesi-rollups-contracts-2.1.1/src/consensus/IOutputsMerkleRootValidator.sol";
-import {IApplication} from "cartesi-rollups-contracts-2.1.1/src/dapp/IApplication.sol";
-import {IApplicationFactory} from "cartesi-rollups-contracts-2.1.1/src/dapp/IApplicationFactory.sol";
-import {IInputBox} from "cartesi-rollups-contracts-2.1.1/src/inputs/IInputBox.sol";
+} from "cartesi-rollups-contracts-2.2.0/src/consensus/IOutputsMerkleRootValidator.sol";
+import {IApplication} from "cartesi-rollups-contracts-2.2.0/src/dapp/IApplication.sol";
+import {IApplicationFactory} from "cartesi-rollups-contracts-2.2.0/src/dapp/IApplicationFactory.sol";
+import {IInputBox} from "cartesi-rollups-contracts-2.2.0/src/inputs/IInputBox.sol";
 
 import {ITournamentFactory} from "prt-contracts/ITournamentFactory.sol";
 import {Machine} from "prt-contracts/types/Machine.sol";

--- a/cartesi-rollups/contracts/src/DaveConsensus.sol
+++ b/cartesi-rollups/contracts/src/DaveConsensus.sol
@@ -8,9 +8,9 @@ import {IERC165} from "@openzeppelin-contracts-5.2.0/utils/introspection/IERC165
 
 import {
     IOutputsMerkleRootValidator
-} from "cartesi-rollups-contracts-2.1.1/src/consensus/IOutputsMerkleRootValidator.sol";
-import {IInputBox} from "cartesi-rollups-contracts-2.1.1/src/inputs/IInputBox.sol";
-import {LibMerkle32} from "cartesi-rollups-contracts-2.1.1/src/library/LibMerkle32.sol";
+} from "cartesi-rollups-contracts-2.2.0/src/consensus/IOutputsMerkleRootValidator.sol";
+import {IInputBox} from "cartesi-rollups-contracts-2.2.0/src/inputs/IInputBox.sol";
+import {LibMerkle32} from "cartesi-rollups-contracts-2.2.0/src/library/LibMerkle32.sol";
 
 import {IDataProvider} from "prt-contracts/IDataProvider.sol";
 import {ITournament} from "prt-contracts/ITournament.sol";

--- a/cartesi-rollups/contracts/src/IDaveAppFactory.sol
+++ b/cartesi-rollups/contracts/src/IDaveAppFactory.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.8;
 
-import {IApplication} from "cartesi-rollups-contracts-2.1.1/src/dapp/IApplication.sol";
+import {IApplication} from "cartesi-rollups-contracts-2.2.0/src/dapp/IApplication.sol";
 
 import {IDaveConsensus} from "./IDaveConsensus.sol";
 

--- a/cartesi-rollups/contracts/src/IDaveConsensus.sol
+++ b/cartesi-rollups/contracts/src/IDaveConsensus.sol
@@ -5,8 +5,8 @@ pragma solidity ^0.8.8;
 
 import {
     IOutputsMerkleRootValidator
-} from "cartesi-rollups-contracts-2.1.1/src/consensus/IOutputsMerkleRootValidator.sol";
-import {IInputBox} from "cartesi-rollups-contracts-2.1.1/src/inputs/IInputBox.sol";
+} from "cartesi-rollups-contracts-2.2.0/src/consensus/IOutputsMerkleRootValidator.sol";
+import {IInputBox} from "cartesi-rollups-contracts-2.2.0/src/inputs/IInputBox.sol";
 import {IDataProvider} from "prt-contracts/IDataProvider.sol";
 
 import {ITournament} from "prt-contracts/ITournament.sol";

--- a/cartesi-rollups/contracts/test/DaveAppFactory.t.sol
+++ b/cartesi-rollups/contracts/test/DaveAppFactory.t.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.22;
 import {Test} from "forge-std-1.9.6/src/Test.sol";
 import {Vm} from "forge-std-1.9.6/src/Vm.sol";
 
-import {DataAvailability} from "cartesi-rollups-contracts-2.1.1/src/common/DataAvailability.sol";
-import {ApplicationFactory} from "cartesi-rollups-contracts-2.1.1/src/dapp/ApplicationFactory.sol";
-import {IApplication} from "cartesi-rollups-contracts-2.1.1/src/dapp/IApplication.sol";
-import {IApplicationFactory} from "cartesi-rollups-contracts-2.1.1/src/dapp/IApplicationFactory.sol";
-import {IInputBox} from "cartesi-rollups-contracts-2.1.1/src/inputs/IInputBox.sol";
-import {InputBox} from "cartesi-rollups-contracts-2.1.1/src/inputs/InputBox.sol";
+import {DataAvailability} from "cartesi-rollups-contracts-2.2.0/src/common/DataAvailability.sol";
+import {ApplicationFactory} from "cartesi-rollups-contracts-2.2.0/src/dapp/ApplicationFactory.sol";
+import {IApplication} from "cartesi-rollups-contracts-2.2.0/src/dapp/IApplication.sol";
+import {IApplicationFactory} from "cartesi-rollups-contracts-2.2.0/src/dapp/IApplicationFactory.sol";
+import {IInputBox} from "cartesi-rollups-contracts-2.2.0/src/inputs/IInputBox.sol";
+import {InputBox} from "cartesi-rollups-contracts-2.2.0/src/inputs/InputBox.sol";
 
 import {IDataProvider} from "prt-contracts/IDataProvider.sol";
 import {ITournamentFactory} from "prt-contracts/ITournamentFactory.sol";

--- a/cartesi-rollups/contracts/test/DaveConsensus.t.sol
+++ b/cartesi-rollups/contracts/test/DaveConsensus.t.sol
@@ -11,10 +11,10 @@ import {IERC165} from "@openzeppelin-contracts-5.5.0/utils/introspection/IERC165
 
 import {
     IOutputsMerkleRootValidator
-} from "cartesi-rollups-contracts-2.1.1/src/consensus/IOutputsMerkleRootValidator.sol";
-import {IInputBox} from "cartesi-rollups-contracts-2.1.1/src/inputs/IInputBox.sol";
-import {InputBox} from "cartesi-rollups-contracts-2.1.1/src/inputs/InputBox.sol";
-import {LibMerkle32} from "cartesi-rollups-contracts-2.1.1/src/library/LibMerkle32.sol";
+} from "cartesi-rollups-contracts-2.2.0/src/consensus/IOutputsMerkleRootValidator.sol";
+import {IInputBox} from "cartesi-rollups-contracts-2.2.0/src/inputs/IInputBox.sol";
+import {InputBox} from "cartesi-rollups-contracts-2.2.0/src/inputs/InputBox.sol";
+import {LibMerkle32} from "cartesi-rollups-contracts-2.2.0/src/library/LibMerkle32.sol";
 
 import {IDataProvider} from "prt-contracts/IDataProvider.sol";
 import {ITournament} from "prt-contracts/ITournament.sol";


### PR DESCRIPTION
The reference node team needs this bump to fast-sync `getNumberOfSubmittedClaims` events.