### PR TITLE
fix(ci): chmod 755 cartesi-rollups-prt-node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,6 +255,9 @@ jobs:
         with:
           name: cartesi-rollups-prt-node-linux-${{ matrix.arch }}
 
+      - name: Change node binary file permissions
+        run: chmod 755 cartesi-rollups-prt-node
+
       - name: Compress node binary
         run: tar -czf "$FILEPATH" cartesi-rollups-prt-node
         env:


### PR DESCRIPTION
Thanks @endersonmaia for bringing this to my attention.
There should also be a PR targetting the main branch with this fix.