### PR TITLE
fix: cannonfiles (prepare for dave 2.1.1)

### DIFF
--- a/cartesi-rollups/contracts/cannonfile.toml
+++ b/cartesi-rollups/contracts/cannonfile.toml
@@ -1,12 +1,12 @@
 name = 'cartesi-dave-app-factory'
-version = '2.0.0'
+version = '2.1.1'
 description = 'Cartesi Dave App Factory'
 
 [pull.prtContracts]
-source = "cartesi-prt-multilevel:2.0.0@main"
+source = "cartesi-prt-multilevel:2.1.1@main"
 
 [pull.cartesiRollups]
-source = "cartesi-rollups:2.1.0@main"
+source = "cartesi-rollups:2.2.0@main"
 
 [deploy.DaveAppFactory]
 artifact = "DaveAppFactory"
@@ -18,3 +18,24 @@ args = [
 create2 = true
 salt = "<%= zeroHash %>"
 ifExists = "continue"
+
+[deploy.TestFungibleToken]
+artifact = "TestFungibleToken"
+create2 = true
+salt = "<%= zeroHash %>"
+ifExists = "continue"
+chains = [13370]
+
+[deploy.TestNonFungibleToken]
+artifact = "TestNonFungibleToken"
+create2 = true
+salt = "<%= zeroHash %>"
+ifExists = "continue"
+chains = [13370]
+
+[deploy.TestMultiToken]
+artifact = "TestMultiToken"
+create2 = true
+salt = "<%= zeroHash %>"
+ifExists = "continue"
+chains = [13370]

--- a/prt/contracts/cannonfile.toml
+++ b/prt/contracts/cannonfile.toml
@@ -1,5 +1,5 @@
 name = 'cartesi-prt-multilevel'
-version = '2.0.0'
+version = '2.1.1'
 description = 'Cartesi PRT contracts'
 
 [var.MainnetTournamentConstants]
@@ -44,41 +44,8 @@ create2 = true
 salt = "<%= zeroHash %>"
 ifExists = "continue"
 
-[deploy.TopTournament]
-artifact = "TopTournament"
-create2 = true
-salt = "<%= zeroHash %>"
-ifExists = "continue"
-
-[deploy.TopTournamentFactory]
-artifact = "TopTournamentFactory"
-args = ["<%= contracts.TopTournament.address %>"]
-create2 = true
-salt = "<%= zeroHash %>"
-ifExists = "continue"
-
-[deploy.MiddleTournament]
-artifact = "MiddleTournament"
-create2 = true
-salt = "<%= zeroHash %>"
-ifExists = "continue"
-
-[deploy.MiddleTournamentFactory]
-artifact = "MiddleTournamentFactory"
-args = ["<%= contracts.MiddleTournament.address %>"]
-create2 = true
-salt = "<%= zeroHash %>"
-ifExists = "continue"
-
-[deploy.BottomTournament]
-artifact = "BottomTournament"
-create2 = true
-salt = "<%= zeroHash %>"
-ifExists = "continue"
-
-[deploy.BottomTournamentFactory]
-artifact = "BottomTournamentFactory"
-args = ["<%= contracts.BottomTournament.address %>"]
+[deploy.Tournament]
+artifact = "Tournament"
 create2 = true
 salt = "<%= zeroHash %>"
 ifExists = "continue"
@@ -96,9 +63,7 @@ ifExists = "continue"
 [deploy.MultiLevelTournamentFactory]
 artifact = "MultiLevelTournamentFactory"
 args = [
-    "<%= contracts.TopTournamentFactory.address %>",
-    "<%= contracts.MiddleTournamentFactory.address %>",
-    "<%= contracts.BottomTournamentFactory.address %>",
+    "<%= contracts.Tournament.address %>",
     "<%= contracts.CanonicalTournamentParametersProvider.address %>",
     "<%= contracts.CartesiStateTransition.address %>",
 ]


### PR DESCRIPTION
This PR fixes the Cannonfiles so that Cannon and the Forge deployment scripts match.
It also bumps the Cannonfile versions to 2.1.1, preparing for a patch release.