### PR TITLE
feat: bump rollups-contracts from 3.0.0-alpha.3 to 3.0.0-alpha.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "cartesi-rollups-contracts"
-version = "2.1.1"
+version = "3.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f5e916fa85a522e1caa0f4923184c31e6ea4ec851fbfe50b5a3846ea83a0c9"
+checksum = "5155609bc75488ef8e2e11f80078eef7909688a43bcd9fd4df390d4aa4dc64f6"
 dependencies = [
  "alloy",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ cartesi-prt-core = { path = "prt/client-rs/core" }
 ## Dependencies
 
 # cartesi
-cartesi-rollups-contracts = "=2.1.1"
+cartesi-rollups-contracts = "=3.0.0-alpha.4"
 
 # eth
 alloy = { version = "1.0", features = [

--- a/cartesi-rollups/contracts/foundry.toml
+++ b/cartesi-rollups/contracts/foundry.toml
@@ -8,10 +8,10 @@ via_ir = true
 
 allow_paths = ["../../prt/contracts", "../../machine/step"]
 remappings = [
-    "@openzeppelin-contracts-5.2.0/=dependencies/cartesi-rollups-contracts-3.0.0-alpha.3/dependencies/@openzeppelin-contracts-5.2.0/",
+    "@openzeppelin-contracts-5.2.0/=dependencies/cartesi-rollups-contracts-3.0.0-alpha.4/dependencies/@openzeppelin-contracts-5.2.0/",
     "@openzeppelin-contracts-5.5.0/=dependencies/@openzeppelin-contracts-5.5.0/",
-    "cartesi-machine-solidity-step-0.13.0/=dependencies/cartesi-rollups-contracts-3.0.0-alpha.3/dependencies/cartesi-machine-solidity-step-0.13.0/",
-    "cartesi-rollups-contracts-3.0.0/=dependencies/cartesi-rollups-contracts-3.0.0-alpha.3/",
+    "cartesi-machine-solidity-step-0.13.0/=dependencies/cartesi-rollups-contracts-3.0.0-alpha.4/dependencies/cartesi-machine-solidity-step-0.13.0/",
+    "cartesi-rollups-contracts-3.0.0/=dependencies/cartesi-rollups-contracts-3.0.0-alpha.4/",
     "forge-std-1.9.6/=dependencies/forge-std-1.9.6/",
     "prt-contracts/=../../prt/contracts/src/",
     "step/=../../machine/step/",
@@ -21,7 +21,7 @@ solc_version = "0.8.30"
 evm_version = "prague"
 fs_permissions = [
     { access = "read-write", path = "deployments" },
-    { access = "read", path = "dependencies/cartesi-rollups-contracts-3.0.0-alpha.3/deployments" },
+    { access = "read", path = "dependencies/cartesi-rollups-contracts-3.0.0-alpha.4/deployments" },
     { access = "read", path = "../../prt/contracts/deployments" },
 ]
 
@@ -38,4 +38,4 @@ exclude_lints = ["incorrect-shift"]
 [dependencies]
 "@openzeppelin-contracts" = "5.5.0"
 forge-std = "1.9.6"
-cartesi-rollups-contracts = "3.0.0-alpha.3"
+cartesi-rollups-contracts = "3.0.0-alpha.4"

--- a/cartesi-rollups/contracts/script/Deployment.s.sol
+++ b/cartesi-rollups/contracts/script/Deployment.s.sol
@@ -10,7 +10,7 @@ import {DaveAppFactory} from "src/DaveAppFactory.sol";
 contract DeploymentScript is BaseDeploymentScript {
     function run() external {
         _importDeployments("../../prt/contracts");
-        _importDeployments("dependencies/cartesi-rollups-contracts-3.0.0-alpha.3");
+        _importDeployments("dependencies/cartesi-rollups-contracts-3.0.0-alpha.4");
 
         address inputBox = _loadDeployment(".", "InputBox");
         address appFactory = _loadDeployment(".", "ApplicationFactory");

--- a/cartesi-rollups/contracts/script/deploy.sh
+++ b/cartesi-rollups/contracts/script/deploy.sh
@@ -6,7 +6,7 @@ cd "${BASH_SOURCE%/*}/.."
 
 roots=(
     '../../prt/contracts'
-    'dependencies/cartesi-rollups-contracts-3.0.0-alpha.3'
+    'dependencies/cartesi-rollups-contracts-3.0.0-alpha.4'
     '.'
 )
 

--- a/cartesi-rollups/contracts/soldeer.lock
+++ b/cartesi-rollups/contracts/soldeer.lock
@@ -7,10 +7,10 @@ integrity = "da8336cf949f0e0667ae8360af849681e3a3e76d7e61e7a86b1a3414a158aeea"
 
 [[dependencies]]
 name = "cartesi-rollups-contracts"
-version = "3.0.0-alpha.3"
-url = "https://soldeer-revisions.s3.amazonaws.com/cartesi-rollups-contracts/3_0_0-alpha_3_27-03-2026_20:38:21_rollups-contracts.zip"
-checksum = "3d2ef3f5647f80d7549eed84b589fb612901c88c6f5f26cdf9b4a44d358b8b9a"
-integrity = "8bb84e8623fc67af07bb7c096d49e0cc9cc1702a1cf600b7b1b8167ee1af1768"
+version = "3.0.0-alpha.4"
+url = "https://soldeer-revisions.s3.amazonaws.com/cartesi-rollups-contracts/3_0_0-alpha_4_05-05-2026_13:59:19_rollups-contracts.zip"
+checksum = "7e1f938a3f026d25672d060903d3df9f7838f89a4d5b3275235cf131bde084a9"
+integrity = "d3019afac0ab8e35439c19c535689ad7857ffb59e0fdd319d757e533c77427b0"
 
 [[dependencies]]
 name = "forge-std"

--- a/cartesi-rollups/contracts/src/IDaveAppFactory.sol
+++ b/cartesi-rollups/contracts/src/IDaveAppFactory.sol
@@ -5,13 +5,14 @@ pragma solidity ^0.8.8;
 
 import {WithdrawalConfig} from "cartesi-rollups-contracts-3.0.0/src/common/WithdrawalConfig.sol";
 import {IApplication} from "cartesi-rollups-contracts-3.0.0/src/dapp/IApplication.sol";
+import {IApplicationFactoryErrors} from "cartesi-rollups-contracts-3.0.0/src/dapp/IApplicationFactoryErrors.sol";
 
 import {IDaveConsensus} from "./IDaveConsensus.sol";
 
 /// @title Dave-App Pair Factory
 /// @notice Allows anyone to reliably deploy an application
 /// validated a newly-deployed `IDaveConsensus` contract.
-interface IDaveAppFactory {
+interface IDaveAppFactory is IApplicationFactoryErrors {
     /// @notice A Dave-App pair was created.
     /// @param appContract The application contract
     /// @param daveConsensus The Dave consensus contract

--- a/cartesi-rollups/contracts/test/DaveAppFactory.t.sol
+++ b/cartesi-rollups/contracts/test/DaveAppFactory.t.sol
@@ -15,6 +15,7 @@ import {ApplicationFactory} from "cartesi-rollups-contracts-3.0.0/src/dapp/Appli
 import {IApplication} from "cartesi-rollups-contracts-3.0.0/src/dapp/IApplication.sol";
 import {IApplicationChecker} from "cartesi-rollups-contracts-3.0.0/src/dapp/IApplicationChecker.sol";
 import {IApplicationFactory} from "cartesi-rollups-contracts-3.0.0/src/dapp/IApplicationFactory.sol";
+import {IApplicationFactoryErrors} from "cartesi-rollups-contracts-3.0.0/src/dapp/IApplicationFactoryErrors.sol";
 import {IInputBox} from "cartesi-rollups-contracts-3.0.0/src/inputs/IInputBox.sol";
 import {InputBox} from "cartesi-rollups-contracts-3.0.0/src/inputs/InputBox.sol";
 import {LibBinaryMerkleTree} from "cartesi-rollups-contracts-3.0.0/src/library/LibBinaryMerkleTree.sol";
@@ -671,14 +672,9 @@ contract DaveAppFactoryTest is Test {
     function _testNewDaveAppFailure(WithdrawalConfig calldata withdrawalConfig, bytes memory errorData) internal pure {
         (bool isValidError, bytes32 errorSelector, bytes memory errorArgs) = errorData.consumeBytes4();
         assertTrue(isValidError, "Expected error to contain a 4-byte selector");
-        if (errorSelector == bytes4(keccak256("Error(string)"))) {
-            string memory errorMsg = abi.decode(errorArgs, (string));
-            bytes32 errorMsgHash = keccak256(bytes(errorMsg));
-            if (errorMsgHash == keccak256("Invalid withdrawal config")) {
-                assertFalse(withdrawalConfig.isValid(), "Expected withdrawal config to be invalid");
-            } else {
-                revert("Unexpected error message");
-            }
+        if (errorSelector == IApplicationFactoryErrors.InvalidWithdrawalConfig.selector) {
+            assertEq(errorArgs, abi.encode(withdrawalConfig), "Expected withdrawal configs to match");
+            assertFalse(withdrawalConfig.isValid(), "Expected withdrawal config to be invalid");
         } else {
             revert("Unexpected error");
         }


### PR DESCRIPTION
The only non-trivial changes are:

- Make `IDaveAppFactory` inherit from `IApplicationFactoryErrors`
- Adjust the tests: `Error("Invalid withdrawal config") -> InvalidWithdrawalConfig(config)`