### PR TITLE
fix: bump Debian and Boost on CI and Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,6 @@ jobs:
           - arch: arm64
             target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
-    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ${{ matrix.os }}
     container:
       image: rust:1.90-trixie

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,7 +175,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ${{ matrix.os }}
     container:
-      image: rust:1.90-bookworm
+      image: rust:1.90-trixie
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:
@@ -189,7 +189,7 @@ jobs:
           apt-get install -y --no-install-recommends \
           build-essential git wget curl \
           liblua5.4-dev lua5.4 \
-          libslirp-dev libboost1.81-dev \
+          libslirp-dev libboost1.83-dev \
           libclang-dev \
           xxd jq sqlite3
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,12 +1,13 @@
 # syntax=docker.io/docker/dockerfile:1
 
-ARG RUST_VERSION=1.86
+ARG RUST_VERSION=1.90
+ARG DEBIAN_VERSION=trixie
 ARG FOUNDRY_VERSION=1.4.3
 ARG PNPM_VERSION=10.7.0
 ARG JUST_VERSION=1.46.0
 
 #### base stage
-FROM rust:${RUST_VERSION} AS base
+FROM rust:${RUST_VERSION}-${DEBIAN_VERSION} AS base
 ARG DEBIAN_FRONTEND=noninteractive
 SHELL ["/usr/bin/env", "bash", "-euo", "pipefail", "-c"]
 RUN <<EOF


### PR DESCRIPTION
In #241, we have bumped the Machine Emulator from 0.19.0 to 0.20.0, but we forgot to bump the dependencies necessary to build it in the CI and in the Dockerfile. This led the CI to fail building the node binaries for the `v3.0.0-alpha.1` release. We should patch this so that we at least have binaries available on GitHub Releases.

- Debian 12 (Bookworm) -> 13 (Trixie)
  - GCC 12 -> 14 (fully supports C++23)
  - Lua 5.4.4 -> 5.4.7

- Boost 1.81 -> 1.83