### PR TITLE
ci: lock GH actions by digest

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -29,11 +29,11 @@ runs:
   using: composite
   steps:
     - name: Set up QEMU for riscv support
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       if: ${{ inputs.setup-qemu == 'true' }}
 
     - name: Install Rust
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       if: ${{ inputs.setup-rust == 'true' }}
       with:
         components: rustfmt
@@ -49,19 +49,19 @@ runs:
         echo "version=${{ inputs.foundry-version }}" >> $GITHUB_OUTPUT
 
     - name: Install Foundry
-      uses: foundry-rs/foundry-toolchain@v1
+      uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
       with:
         version: ${{ steps.set-foundry-version.outputs.version }}
 
     - name: Install just
-      uses: extractions/setup-just@v3
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
       with:
         package_json_file: 'prt/contracts/package.json'
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 22
         cache: 'pnpm'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   prt-contracts:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
 
@@ -36,7 +36,7 @@ jobs:
   dave-contracts:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
 
@@ -63,7 +63,7 @@ jobs:
   prt-honeypot:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
       - name: Setup tools
@@ -110,7 +110,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
 
@@ -178,7 +178,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
 
@@ -223,7 +223,7 @@ jobs:
           cp -v ./target/${{ matrix.target }}/release/cartesi-rollups-prt-node cartesi-rollups-prt-node
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cartesi-rollups-prt-node-linux-${{ matrix.arch }}
           path: |
@@ -241,7 +241,7 @@ jobs:
           - arch: arm64
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Create directory
         run: mkdir -p upload
@@ -250,7 +250,7 @@ jobs:
         id: extract_version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cartesi-rollups-prt-node-linux-${{ matrix.arch }}
 
@@ -273,7 +273,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
 


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references to immutable commit digests instead of mutable version tags (e.g. `@v4` → `@de0fac2e...`)
- Affected files: `.github/workflows/build.yml` and `.github/actions/setup-tools/action.yml`
- Pinned actions: `actions/checkout`, `actions/upload-artifact`, `actions/download-artifact`, `docker/setup-qemu-action`, `actions-rust-lang/setup-rust-toolchain`, `foundry-rs/foundry-toolchain`, `extractions/setup-just`, `pnpm/action-setup`, `actions/setup-node`

## Motivation

Mutable version tags (like `@v4`) can be silently repointed to a different — potentially malicious — commit. Pinning by SHA digest ensures the exact code that was reviewed is what runs, protecting against supply chain attacks on the CI pipeline.
