### PR TITLE
Prepare for alpha release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,13 +308,24 @@ jobs:
         env:
           FILEPATH: upload/cartesi-rollups-prt-${{ steps.extract_version.outputs.version }}-contract-artifacts.tar.gz
 
+      - name: Simulate deployment to supported testnets and mainnets
+        working-directory: ./cartesi-rollups/contracts
+        run: |
+          ./script/deploy-testnets.sh
+          ./script/deploy-mainnets.sh
+
+      - name: Compress testnet and mainnet deployment simulation artifacts
+        run: tar -czf "$FILEPATH" -C cartesi-rollups/contracts deployments
+        env:
+          FILEPATH: upload/cartesi-rollups-prt-${{ steps.extract_version.outputs.version }}-deployment-addresses.tar.gz
+
       - name: Build devnet
         working-directory: ./cartesi-rollups/contracts
         run: |
           just build-devnet
 
       - name: Compress devnet artifacts
-        run: tar -czf "$FILEPATH" -C cartesi-rollups/contracts deployments state.json
+        run: tar -czf "$FILEPATH" -C cartesi-rollups/contracts deployments/31337 state.json
         env:
           FILEPATH: upload/cartesi-rollups-prt-${{ steps.extract_version.outputs.version }}-anvil-${{ steps.setup.outputs.installed-foundry-version }}.tar.gz
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,7 +271,6 @@ jobs:
   release-contracts:
     needs: [prt-contracts, dave-contracts, prt-honeypot, build]
     runs-on: ubuntu-24.04
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4
         with:
@@ -283,7 +282,12 @@ jobs:
 
       - name: Extract version from tag
         id: extract_version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          else
+            echo "version=0.0.0-dev" >> $GITHUB_OUTPUT
+          fi
 
       - name: Setup tools
         uses: ./.github/actions/setup-tools
@@ -330,6 +334,7 @@ jobs:
           FILEPATH: upload/cartesi-rollups-prt-${{ steps.extract_version.outputs.version }}-anvil-${{ steps.setup.outputs.installed-foundry-version }}.tar.gz
 
       - name: Upload assets to release on GitHub
+        if: startsWith(github.ref, 'refs/tags/v')
         run: gh release upload "$TAG" upload/* --clobber
         env:
           GH_TOKEN: ${{ github.token }}

--- a/cartesi-rollups/contracts/foundry.toml
+++ b/cartesi-rollups/contracts/foundry.toml
@@ -8,10 +8,10 @@ via_ir = true
 
 allow_paths = ["../../prt/contracts", "../../machine/step"]
 remappings = [
-    "@openzeppelin-contracts-5.2.0/=dependencies/cartesi-rollups-contracts-3.0.0-alpha.4/dependencies/@openzeppelin-contracts-5.2.0/",
+    "@openzeppelin-contracts-5.2.0/=dependencies/cartesi-rollups-contracts-3.0.0-alpha.5/dependencies/@openzeppelin-contracts-5.2.0/",
     "@openzeppelin-contracts-5.5.0/=dependencies/@openzeppelin-contracts-5.5.0/",
-    "cartesi-machine-solidity-step-0.13.0/=dependencies/cartesi-rollups-contracts-3.0.0-alpha.4/dependencies/cartesi-machine-solidity-step-0.13.0/",
-    "cartesi-rollups-contracts-3.0.0/=dependencies/cartesi-rollups-contracts-3.0.0-alpha.4/",
+    "cartesi-machine-solidity-step-0.13.0/=dependencies/cartesi-rollups-contracts-3.0.0-alpha.5/dependencies/cartesi-machine-solidity-step-0.13.0/",
+    "cartesi-rollups-contracts-3.0.0/=dependencies/cartesi-rollups-contracts-3.0.0-alpha.5/",
     "forge-std-1.9.6/=dependencies/forge-std-1.9.6/",
     "prt-contracts/=../../prt/contracts/src/",
     "step/=../../machine/step/",
@@ -21,7 +21,7 @@ solc_version = "0.8.30"
 evm_version = "prague"
 fs_permissions = [
     { access = "read-write", path = "deployments" },
-    { access = "read", path = "dependencies/cartesi-rollups-contracts-3.0.0-alpha.4/deployments" },
+    { access = "read", path = "dependencies/cartesi-rollups-contracts-3.0.0-alpha.5/deployments" },
     { access = "read", path = "../../prt/contracts/deployments" },
 ]
 
@@ -38,4 +38,4 @@ exclude_lints = ["incorrect-shift"]
 [dependencies]
 "@openzeppelin-contracts" = "5.5.0"
 forge-std = "1.9.6"
-cartesi-rollups-contracts = "3.0.0-alpha.4"
+cartesi-rollups-contracts = "3.0.0-alpha.5"

--- a/cartesi-rollups/contracts/script/Deployment.s.sol
+++ b/cartesi-rollups/contracts/script/Deployment.s.sol
@@ -10,7 +10,7 @@ import {DaveAppFactory} from "src/DaveAppFactory.sol";
 contract DeploymentScript is BaseDeploymentScript {
     function run() external {
         _importDeployments("../../prt/contracts");
-        _importDeployments("dependencies/cartesi-rollups-contracts-3.0.0-alpha.4");
+        _importDeployments("dependencies/cartesi-rollups-contracts-3.0.0-alpha.5");
 
         address inputBox = _loadDeployment(".", "InputBox");
         address appFactory = _loadDeployment(".", "ApplicationFactory");

--- a/cartesi-rollups/contracts/script/deploy-mainnets.sh
+++ b/cartesi-rollups/contracts/script/deploy-mainnets.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "${BASH_SOURCE%/*}/.."
+
+chain_ids=(
+    1          # Ethereum Mainnet
+    10         # OP Mainnet
+    8453       # Base Mainnet
+    42161      # Arbitrum Mainnet
+)
+
+for chain_id in "${chain_ids[@]}"
+do
+    ./script/deploy.sh --chain-id "$chain_id" "$@"
+done

--- a/cartesi-rollups/contracts/script/deploy-testnets.sh
+++ b/cartesi-rollups/contracts/script/deploy-testnets.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "${BASH_SOURCE%/*}/.."
+
+chain_ids=(
+    84532      # Base Sepolia
+    421614     # Arbitrum Sepolia
+    11155111   # Ethereum Sepolia
+    11155420   # OP Sepolia
+)
+
+for chain_id in "${chain_ids[@]}"
+do
+    ./script/deploy.sh --chain-id "$chain_id" "$@"
+done

--- a/cartesi-rollups/contracts/script/deploy.sh
+++ b/cartesi-rollups/contracts/script/deploy.sh
@@ -6,7 +6,7 @@ cd "${BASH_SOURCE%/*}/.."
 
 roots=(
     '../../prt/contracts'
-    'dependencies/cartesi-rollups-contracts-3.0.0-alpha.4'
+    'dependencies/cartesi-rollups-contracts-3.0.0-alpha.5'
     '.'
 )
 

--- a/cartesi-rollups/contracts/soldeer.lock
+++ b/cartesi-rollups/contracts/soldeer.lock
@@ -7,10 +7,10 @@ integrity = "da8336cf949f0e0667ae8360af849681e3a3e76d7e61e7a86b1a3414a158aeea"
 
 [[dependencies]]
 name = "cartesi-rollups-contracts"
-version = "3.0.0-alpha.4"
-url = "https://soldeer-revisions.s3.amazonaws.com/cartesi-rollups-contracts/3_0_0-alpha_4_05-05-2026_13:59:19_rollups-contracts.zip"
-checksum = "7e1f938a3f026d25672d060903d3df9f7838f89a4d5b3275235cf131bde084a9"
-integrity = "d3019afac0ab8e35439c19c535689ad7857ffb59e0fdd319d757e533c77427b0"
+version = "3.0.0-alpha.5"
+url = "https://soldeer-revisions.s3.amazonaws.com/cartesi-rollups-contracts/3_0_0-alpha_5_19-05-2026_01:12:42_rollups-contracts.zip"
+checksum = "5a1cf8a90d344a0bb4a109556b842dc97ceedc84a5ede00f6e7ce14e2c892984"
+integrity = "4f3d17b92ee51d52e29c8ac57f93faa404157d1d79400a12a3af4e31e912223e"
 
 [[dependencies]]
 name = "forge-std"


### PR DESCRIPTION
This PR:

- bumps rollups-contracts from 3.0.0-alpha.4 to 3.0.0-alpha.5
- makes CI generate and publish artifact with testnet/mainnet deployment addresses
- alters the contract artifact CI job to dry-run on PRs and non-tag pushes