### PR TITLE
Claim staging

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -12,7 +12,7 @@ inputs:
   foundry-version:
     description: 'Foundry version to install'
     required: false
-    default: 'v1.4.3'
+    default: 'v1.5.1'
   setup-qemu:
     description: 'Whether to setup QEMU for riscv support'
     required: false

--- a/cartesi-rollups/contracts/script/Deployment.s.sol
+++ b/cartesi-rollups/contracts/script/Deployment.s.sol
@@ -1,7 +1,7 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.30;
 
 import {BaseDeploymentScript} from "prt-contracts/../script/BaseDeploymentScript.sol";
 

--- a/cartesi-rollups/contracts/src/DaveAppFactory.sol
+++ b/cartesi-rollups/contracts/src/DaveAppFactory.sol
@@ -37,11 +37,12 @@ contract DaveAppFactory is IDaveAppFactory {
     function newDaveApp(
         bytes32 templateHash,
         uint256 claimStagingPeriod,
+        address[] calldata sentries,
         WithdrawalConfig calldata withdrawalConfig,
         bytes32 salt
     ) external override returns (IApplication appContract, IDaveConsensus daveConsensus) {
         appContract = _newApplication(templateHash, withdrawalConfig, salt);
-        daveConsensus = _newDaveConsensus(address(appContract), templateHash, claimStagingPeriod, salt);
+        daveConsensus = _newDaveConsensus(address(appContract), templateHash, claimStagingPeriod, sentries, salt);
         appContract.migrateToOutputsMerkleRootValidator(daveConsensus);
         appContract.renounceOwnership();
         emit DaveAppCreated(appContract, daveConsensus);
@@ -50,12 +51,13 @@ contract DaveAppFactory is IDaveAppFactory {
     function calculateDaveAppAddress(
         bytes32 templateHash,
         uint256 claimStagingPeriod,
+        address[] calldata sentries,
         WithdrawalConfig calldata withdrawalConfig,
         bytes32 salt
     ) external view override returns (address appContractAddress, address daveConsensusAddress) {
         appContractAddress = _calculateApplicationAddress(templateHash, withdrawalConfig, salt);
         daveConsensusAddress =
-            _calculateDaveConsensusAddress(appContractAddress, templateHash, claimStagingPeriod, salt);
+            _calculateDaveConsensusAddress(appContractAddress, templateHash, claimStagingPeriod, sentries, salt);
     }
 
     /// @notice Encode the data availability blob for applications that only use the input box as DA.
@@ -78,13 +80,16 @@ contract DaveAppFactory is IDaveAppFactory {
     }
 
     /// @notice Instantiate a new `DaveConsensus` contract.
-    function _newDaveConsensus(address appContract, bytes32 templateHash, uint256 claimStagingPeriod, bytes32 salt)
-        internal
-        returns (DaveConsensus)
-    {
+    function _newDaveConsensus(
+        address appContract,
+        bytes32 templateHash,
+        uint256 claimStagingPeriod,
+        address[] calldata sentries,
+        bytes32 salt
+    ) internal returns (DaveConsensus) {
         Machine.Hash initialMachineStateHash = Machine.Hash.wrap(templateHash);
         return new DaveConsensus{salt: salt}(
-            INPUT_BOX, appContract, TOURNAMENT_FACTORY, initialMachineStateHash, claimStagingPeriod
+            INPUT_BOX, appContract, TOURNAMENT_FACTORY, initialMachineStateHash, claimStagingPeriod, sentries
         );
     }
 
@@ -105,6 +110,7 @@ contract DaveAppFactory is IDaveAppFactory {
         address appContract,
         bytes32 templateHash,
         uint256 claimStagingPeriod,
+        address[] calldata sentries,
         bytes32 salt
     ) internal view returns (address) {
         return Create2.computeAddress(
@@ -112,7 +118,7 @@ contract DaveAppFactory is IDaveAppFactory {
             keccak256(
                 abi.encodePacked(
                     type(DaveConsensus).creationCode,
-                    abi.encode(INPUT_BOX, appContract, TOURNAMENT_FACTORY, templateHash, claimStagingPeriod)
+                    abi.encode(INPUT_BOX, appContract, TOURNAMENT_FACTORY, templateHash, claimStagingPeriod, sentries)
                 )
             )
         );

--- a/cartesi-rollups/contracts/src/DaveAppFactory.sol
+++ b/cartesi-rollups/contracts/src/DaveAppFactory.sol
@@ -1,7 +1,7 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.30;
 
 import {Create2} from "@openzeppelin-contracts-5.5.0/utils/Create2.sol";
 

--- a/cartesi-rollups/contracts/src/DaveAppFactory.sol
+++ b/cartesi-rollups/contracts/src/DaveAppFactory.sol
@@ -37,12 +37,14 @@ contract DaveAppFactory is IDaveAppFactory {
     function newDaveApp(
         bytes32 templateHash,
         uint256 claimStagingPeriod,
+        address sentryManager,
         address[] calldata sentries,
         WithdrawalConfig calldata withdrawalConfig,
         bytes32 salt
     ) external override returns (IApplication appContract, IDaveConsensus daveConsensus) {
         appContract = _newApplication(templateHash, withdrawalConfig, salt);
-        daveConsensus = _newDaveConsensus(address(appContract), templateHash, claimStagingPeriod, sentries, salt);
+        daveConsensus =
+            _newDaveConsensus(address(appContract), templateHash, claimStagingPeriod, sentryManager, sentries, salt);
         appContract.migrateToOutputsMerkleRootValidator(daveConsensus);
         appContract.renounceOwnership();
         emit DaveAppCreated(appContract, daveConsensus);
@@ -51,13 +53,15 @@ contract DaveAppFactory is IDaveAppFactory {
     function calculateDaveAppAddress(
         bytes32 templateHash,
         uint256 claimStagingPeriod,
+        address sentryManager,
         address[] calldata sentries,
         WithdrawalConfig calldata withdrawalConfig,
         bytes32 salt
     ) external view override returns (address appContractAddress, address daveConsensusAddress) {
         appContractAddress = _calculateApplicationAddress(templateHash, withdrawalConfig, salt);
-        daveConsensusAddress =
-            _calculateDaveConsensusAddress(appContractAddress, templateHash, claimStagingPeriod, sentries, salt);
+        daveConsensusAddress = _calculateDaveConsensusAddress(
+            appContractAddress, templateHash, claimStagingPeriod, sentryManager, sentries, salt
+        );
     }
 
     /// @notice Encode the data availability blob for applications that only use the input box as DA.
@@ -84,12 +88,19 @@ contract DaveAppFactory is IDaveAppFactory {
         address appContract,
         bytes32 templateHash,
         uint256 claimStagingPeriod,
+        address sentryManager,
         address[] calldata sentries,
         bytes32 salt
     ) internal returns (DaveConsensus) {
         Machine.Hash initialMachineStateHash = Machine.Hash.wrap(templateHash);
         return new DaveConsensus{salt: salt}(
-            INPUT_BOX, appContract, TOURNAMENT_FACTORY, initialMachineStateHash, claimStagingPeriod, sentries
+            INPUT_BOX,
+            appContract,
+            TOURNAMENT_FACTORY,
+            initialMachineStateHash,
+            claimStagingPeriod,
+            sentryManager,
+            sentries
         );
     }
 
@@ -110,6 +121,7 @@ contract DaveAppFactory is IDaveAppFactory {
         address appContract,
         bytes32 templateHash,
         uint256 claimStagingPeriod,
+        address sentryManager,
         address[] calldata sentries,
         bytes32 salt
     ) internal view returns (address) {
@@ -118,7 +130,15 @@ contract DaveAppFactory is IDaveAppFactory {
             keccak256(
                 abi.encodePacked(
                     type(DaveConsensus).creationCode,
-                    abi.encode(INPUT_BOX, appContract, TOURNAMENT_FACTORY, templateHash, claimStagingPeriod, sentries)
+                    abi.encode(
+                        INPUT_BOX,
+                        appContract,
+                        TOURNAMENT_FACTORY,
+                        templateHash,
+                        claimStagingPeriod,
+                        sentryManager,
+                        sentries
+                    )
                 )
             )
         );

--- a/cartesi-rollups/contracts/src/DaveAppFactory.sol
+++ b/cartesi-rollups/contracts/src/DaveAppFactory.sol
@@ -34,26 +34,28 @@ contract DaveAppFactory is IDaveAppFactory {
         TOURNAMENT_FACTORY = tournamentFactory;
     }
 
-    function newDaveApp(bytes32 templateHash, WithdrawalConfig calldata withdrawalConfig, bytes32 salt)
-        external
-        override
-        returns (IApplication appContract, IDaveConsensus daveConsensus)
-    {
+    function newDaveApp(
+        bytes32 templateHash,
+        uint256 claimStagingPeriod,
+        WithdrawalConfig calldata withdrawalConfig,
+        bytes32 salt
+    ) external override returns (IApplication appContract, IDaveConsensus daveConsensus) {
         appContract = _newApplication(templateHash, withdrawalConfig, salt);
-        daveConsensus = _newDaveConsensus(address(appContract), templateHash, salt);
+        daveConsensus = _newDaveConsensus(address(appContract), templateHash, claimStagingPeriod, salt);
         appContract.migrateToOutputsMerkleRootValidator(daveConsensus);
         appContract.renounceOwnership();
         emit DaveAppCreated(appContract, daveConsensus);
     }
 
-    function calculateDaveAppAddress(bytes32 templateHash, WithdrawalConfig calldata withdrawalConfig, bytes32 salt)
-        external
-        view
-        override
-        returns (address appContractAddress, address daveConsensusAddress)
-    {
+    function calculateDaveAppAddress(
+        bytes32 templateHash,
+        uint256 claimStagingPeriod,
+        WithdrawalConfig calldata withdrawalConfig,
+        bytes32 salt
+    ) external view override returns (address appContractAddress, address daveConsensusAddress) {
         appContractAddress = _calculateApplicationAddress(templateHash, withdrawalConfig, salt);
-        daveConsensusAddress = _calculateDaveConsensusAddress(appContractAddress, templateHash, salt);
+        daveConsensusAddress =
+            _calculateDaveConsensusAddress(appContractAddress, templateHash, claimStagingPeriod, salt);
     }
 
     /// @notice Encode the data availability blob for applications that only use the input box as DA.
@@ -76,12 +78,14 @@ contract DaveAppFactory is IDaveAppFactory {
     }
 
     /// @notice Instantiate a new `DaveConsensus` contract.
-    function _newDaveConsensus(address appContract, bytes32 templateHash, bytes32 salt)
+    function _newDaveConsensus(address appContract, bytes32 templateHash, uint256 claimStagingPeriod, bytes32 salt)
         internal
         returns (DaveConsensus)
     {
         Machine.Hash initialMachineStateHash = Machine.Hash.wrap(templateHash);
-        return new DaveConsensus{salt: salt}(INPUT_BOX, appContract, TOURNAMENT_FACTORY, initialMachineStateHash);
+        return new DaveConsensus{salt: salt}(
+            INPUT_BOX, appContract, TOURNAMENT_FACTORY, initialMachineStateHash, claimStagingPeriod
+        );
     }
 
     /// @notice Calculates the address of an application contract.
@@ -97,17 +101,18 @@ contract DaveAppFactory is IDaveAppFactory {
     }
 
     /// @notice Calculates the address of a `DaveConsensus` contract.
-    function _calculateDaveConsensusAddress(address appContract, bytes32 templateHash, bytes32 salt)
-        internal
-        view
-        returns (address)
-    {
+    function _calculateDaveConsensusAddress(
+        address appContract,
+        bytes32 templateHash,
+        uint256 claimStagingPeriod,
+        bytes32 salt
+    ) internal view returns (address) {
         return Create2.computeAddress(
             salt,
             keccak256(
                 abi.encodePacked(
                     type(DaveConsensus).creationCode,
-                    abi.encode(INPUT_BOX, appContract, TOURNAMENT_FACTORY, templateHash)
+                    abi.encode(INPUT_BOX, appContract, TOURNAMENT_FACTORY, templateHash, claimStagingPeriod)
                 )
             )
         );

--- a/cartesi-rollups/contracts/src/DaveConsensus.sol
+++ b/cartesi-rollups/contracts/src/DaveConsensus.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.8;
 
 import {ERC165} from "@openzeppelin-contracts-5.2.0/utils/introspection/ERC165.sol";
 import {IERC165} from "@openzeppelin-contracts-5.2.0/utils/introspection/IERC165.sol";
+import {BitMaps} from "@openzeppelin-contracts-5.2.0/utils/structs/BitMaps.sol";
 
 import {
     IOutputsMerkleRootValidator
@@ -29,6 +30,7 @@ import {IDaveConsensus} from "./IDaveConsensus.sol";
 
 contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
     using LibMath for uint256;
+    using BitMaps for BitMaps.BitMap;
     using LibBinaryMerkleTree for bytes;
     using LibBinaryMerkleTree for bytes32[];
 
@@ -46,6 +48,10 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
 
     /// @notice Deployment block number
     uint256 immutable _DEPLOYMENT_BLOCK_NUMBER = block.number;
+
+    /// @notice The total number of sentries.
+    /// @notice See the `getNumberOfSentries` function.
+    uint256 immutable _NUM_OF_SENTRIES;
 
     /// @notice Current sealed epoch number
     uint256 _epochNumber;
@@ -80,18 +86,45 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
     /// @notice Last-finalized machine state hash
     Machine.Hash _lastFinalizedMachineStateHash;
 
+    /// @notice Sentry IDs indexed by address.
+    /// @notice See the `getSentryId` function.
+    /// @dev Non-sentries are assigned to ID zero.
+    /// @dev Sentries have IDs greater than zero.
+    mapping(address => uint256) private _sentryId;
+
+    /// @notice Sentry addresses indexed by ID.
+    /// @notice See the `getSentryById` function.
+    /// @dev Invalid IDs map to address zero.
+    mapping(uint256 => address) private _sentryById;
+
+    /// @notice A mapping that keeps track of which sentries have claimed in any given epoch.
+    /// @notice See the `hasSentryClaimedInEpoch` function.
+    mapping(uint256 => BitMaps.BitMap) private _epochClaimBitMap;
+
+    /// @notice A mapping that keeps track of post-epoch machine state hash claim counts per epoch.
+    /// @notice See the `getSentryClaimCount` function.
+    mapping(uint256 => mapping(Machine.Hash => uint256)) private _claimCount;
+
     constructor(
         IInputBox inputBox,
         address appContract,
         ITournamentFactory tournamentFactory,
         Machine.Hash initialMachineStateHash,
-        uint256 claimStagingPeriod
+        uint256 claimStagingPeriod,
+        address[] memory sentries
     ) {
         // Initialize immutable variables
         _INPUT_BOX = inputBox;
         _APP_CONTRACT = appContract;
         _TOURNAMENT_FACTORY = tournamentFactory;
         _CLAIM_STAGING_PERIOD = claimStagingPeriod;
+        for (uint256 i; i < sentries.length; ++i) {
+            address sentry = sentries[i];
+            _ensureSentryAddressIsValid(sentry);
+            uint256 sentryId = ++_NUM_OF_SENTRIES;
+            _sentryId[sentry] = sentryId;
+            _sentryById[sentryId] = sentry;
+        }
         emit ConsensusCreation(inputBox, appContract, tournamentFactory);
 
         // Initialize first sealed epoch
@@ -150,12 +183,38 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
         emit EpochStaged(epochNumber, finalMachineStateHash, outputsMerkleRoot);
     }
 
+    function submitSentryClaim(uint256 epochNumber, Machine.Hash postEpochMachineStateHash)
+        external
+        override
+        notForeclosed(_APP_CONTRACT)
+    {
+        // Check whether caller is authorized
+        address caller = msg.sender;
+        uint256 sentryId = getSentryId(caller);
+        require(sentryId > 0, CallerIsNotSentry(caller));
+
+        // Check epoch settlement
+        require(epochNumber == _epochNumber, IncorrectEpochNumber(epochNumber, _epochNumber));
+
+        // Check whether sentry has claimed in epoch already
+        BitMaps.BitMap storage epochClaimBitMap = _epochClaimBitMap[epochNumber];
+        require(!epochClaimBitMap.get(sentryId), SentryAlreadyClaimed(epochNumber, sentryId));
+
+        // Mark epoch as claimed (for sentry) and increment claim count for post-epoch state hash
+        epochClaimBitMap.set(sentryId);
+        ++_claimCount[epochNumber][postEpochMachineStateHash];
+
+        // Emit sentry claim event so that off-chain components can update their tallies
+        emit SentryClaim(epochNumber, sentryId, caller, postEpochMachineStateHash);
+    }
+
     function canAcceptStagedTournamentResult()
         external
         view
         override
         returns (
             bool isTournamentResultStaged,
+            bool doAllSentriesAgreeWithStagedTournamentResult,
             bool isClaimStagingPeriodOver,
             uint256 epochNumber,
             Machine.Hash stagedPostEpochMachineStateHash,
@@ -165,6 +224,7 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
         epochNumber = _epochNumber;
         isTournamentResultStaged = _isTournamentResultStaged;
         if (_isTournamentResultStaged) {
+            doAllSentriesAgreeWithStagedTournamentResult = _doAllSentriesAgreeWithStagedTournamentResult();
             isClaimStagingPeriodOver = ((block.number - _stagingBlockNumber) >= _CLAIM_STAGING_PERIOD);
             stagedPostEpochMachineStateHash = _stagedPostEpochMachineStateHash;
             stagedPostEpochOutputsMerkleRoot = _stagedPostEpochOutputsMerkleRoot;
@@ -179,7 +239,8 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
         require(_isTournamentResultStaged, TournamentResultNotStaged());
 
         // Check whether the claim staging period has elapsed
-        {
+        // if not all sentries agree with the staged tournament result
+        if (!_doAllSentriesAgreeWithStagedTournamentResult()) {
             uint256 numberOfBlocksAfterStaging = block.number - _stagingBlockNumber;
             require(
                 numberOfBlocksAfterStaging >= _CLAIM_STAGING_PERIOD,
@@ -255,6 +316,31 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
         return _CLAIM_STAGING_PERIOD;
     }
 
+    function getNumberOfSentries() external view override returns (uint256) {
+        return _NUM_OF_SENTRIES;
+    }
+
+    function getSentryId(address sentry) public view override returns (uint256) {
+        return _sentryId[sentry];
+    }
+
+    function getSentryById(uint256 sentryId) external view override returns (address) {
+        return _sentryById[sentryId];
+    }
+
+    function hasSentryClaimedInEpoch(uint256 epochNumber, uint256 sentryId) external view override returns (bool) {
+        return _epochClaimBitMap[epochNumber].get(sentryId);
+    }
+
+    function getSentryClaimCount(uint256 epochNumber, Machine.Hash postEpochMachineStateHash)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return _claimCount[epochNumber][postEpochMachineStateHash];
+    }
+
     function provideMerkleRootOfInput(uint256 inputIndexWithinEpoch, bytes calldata input)
         external
         view
@@ -323,6 +409,10 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
         require(machineStateHash == allegedStateHash, InvalidOutputsMerkleRootProof(finalMachineStateHash));
     }
 
+    function _doAllSentriesAgreeWithStagedTournamentResult() internal view returns (bool) {
+        return _NUM_OF_SENTRIES > 0 && _claimCount[_epochNumber][_stagedPostEpochMachineStateHash] == _NUM_OF_SENTRIES;
+    }
+
     modifier onlyValidAppContract(address appContract) {
         _ensureAppContractIsValid(appContract);
         _;
@@ -330,5 +420,11 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
 
     function _ensureAppContractIsValid(address appContract) internal view {
         require(_APP_CONTRACT == appContract, ApplicationMismatch(_APP_CONTRACT, appContract));
+    }
+
+    function _ensureSentryAddressIsValid(address sentry) internal view {
+        require(sentry != address(0), ZeroSentryAddress());
+        uint256 sentryId = getSentryId(sentry);
+        require(sentryId == 0, DuplicatedSentryAddress(sentryId, sentry));
     }
 }

--- a/cartesi-rollups/contracts/src/DaveConsensus.sol
+++ b/cartesi-rollups/contracts/src/DaveConsensus.sol
@@ -27,28 +27,6 @@ import {Memory} from "step/src/Memory.sol";
 
 import {IDaveConsensus} from "./IDaveConsensus.sol";
 
-/// @notice Consensus contract with Dave tournaments.
-///
-/// @notice This contract validates only one application,
-/// which read inputs from the InputBox contract.
-///
-/// @notice This contract also manages epoch boundaries, which
-/// are defined in terms of block numbers. We represent them
-/// as intervals of the form [a,b). They are also identified by
-/// incremental numbers that start from 0.
-///
-/// @notice Off-chain nodes can listen to `EpochSealed` events
-/// to know where epochs start and end, and which epochs have been
-/// settled already and which one is open for challenges still.
-/// Anyone can settle an epoch by calling `settle`.
-/// One can also check if it can be settled by calling `canSettle`.
-///
-/// @notice At any given time, there is always one sealed epoch.
-/// Prior to it, every epoch has been settled.
-/// After it, the next epoch is accumulating inputs. Once this epoch is settled,
-/// the accumlating epoch will be sealed, and a new
-/// accumulating epoch will be created.
-///
 contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
     using LibMath for uint256;
     using LibBinaryMerkleTree for bytes;
@@ -62,6 +40,9 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
 
     /// @notice The contract used to instantiate tournaments
     ITournamentFactory immutable _TOURNAMENT_FACTORY;
+
+    /// @notice The claim staging period
+    uint256 immutable _CLAIM_STAGING_PERIOD;
 
     /// @notice Deployment block number
     uint256 immutable _DEPLOYMENT_BLOCK_NUMBER = block.number;
@@ -78,6 +59,21 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
     /// @notice Current sealed epoch tournament
     ITournament _tournament;
 
+    /// @notice Whether the result of the current sealed epoch tournament is staged
+    bool _isTournamentResultStaged;
+
+    /// @notice The number of the block in which the tournament result was staged
+    /// @dev Only meaningful if _isTournamentResultStaged is true.
+    uint256 _stagingBlockNumber;
+
+    /// @notice The staged post-epoch machine state hash
+    /// @dev Only meaningful if _isTournamentResultStaged is true.
+    Machine.Hash _stagedPostEpochMachineStateHash;
+
+    /// @notice The staged post-epoch outputs Merkle root
+    /// @dev Only meaningful if _isTournamentResultStaged is true.
+    bytes32 _stagedPostEpochOutputsMerkleRoot;
+
     /// @notice Settled output trees' merkle root hash
     mapping(bytes32 => bool) _outputsMerkleRoots;
 
@@ -88,12 +84,14 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
         IInputBox inputBox,
         address appContract,
         ITournamentFactory tournamentFactory,
-        Machine.Hash initialMachineStateHash
+        Machine.Hash initialMachineStateHash,
+        uint256 claimStagingPeriod
     ) {
         // Initialize immutable variables
         _INPUT_BOX = inputBox;
         _APP_CONTRACT = appContract;
         _TOURNAMENT_FACTORY = tournamentFactory;
+        _CLAIM_STAGING_PERIOD = claimStagingPeriod;
         emit ConsensusCreation(inputBox, appContract, tournamentFactory);
 
         // Initialize first sealed epoch
@@ -104,17 +102,24 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
         emit EpochSealed(0, 0, inputIndexUpperBound, initialMachineStateHash, bytes32(0), tournament);
     }
 
-    function canSettle()
+    function canStageTournamentResult()
         external
         view
         override
-        returns (bool isFinished, uint256 epochNumber, Tree.Node winnerCommitment)
+        returns (
+            bool isFinished,
+            bool isTournamentResultStaged,
+            uint256 epochNumber,
+            Tree.Node winnerCommitment,
+            Machine.Hash winnerPostEpochMachineStateHash
+        )
     {
-        (isFinished, winnerCommitment,) = _tournament.arbitrationResult();
         epochNumber = _epochNumber;
+        isTournamentResultStaged = _isTournamentResultStaged;
+        (isFinished, winnerCommitment, winnerPostEpochMachineStateHash) = _tournament.arbitrationResult();
     }
 
-    function settle(uint256 epochNumber, bytes32 outputsMerkleRoot, bytes32[] calldata proof)
+    function stageTournamentResult(uint256 epochNumber, bytes32 outputsMerkleRoot, bytes32[] calldata proof)
         external
         override
         notForeclosed(_APP_CONTRACT)
@@ -122,14 +127,69 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
         // Check tournament settlement
         require(epochNumber == _epochNumber, IncorrectEpochNumber(epochNumber, _epochNumber));
 
+        // Check whether the tournament result is staged
+        require(!_isTournamentResultStaged, TournamentResultAlreadyStaged());
+
         // Check tournament finished
         (bool isFinished,, Machine.Hash finalMachineStateHash) = _tournament.arbitrationResult();
         require(isFinished, TournamentNotFinishedYet());
-        ITournament oldTournament = _tournament;
-        _tournament = ITournament(address(0));
 
         // Check outputs Merkle root
         _validateOutputTree(finalMachineStateHash, outputsMerkleRoot, proof);
+
+        // Stage tournament result, and store the current block number for
+        // later checking whether the claim staging period has elapsed
+        _stagingBlockNumber = block.number;
+        _stagedPostEpochMachineStateHash = finalMachineStateHash;
+        _stagedPostEpochOutputsMerkleRoot = outputsMerkleRoot;
+        _isTournamentResultStaged = true;
+
+        // Try recovering bond for tournament winner
+        try _tournament.tryRecoveringBond() {} catch {}
+
+        emit EpochStaged(epochNumber, finalMachineStateHash, outputsMerkleRoot);
+    }
+
+    function canAcceptStagedTournamentResult()
+        external
+        view
+        override
+        returns (
+            bool isTournamentResultStaged,
+            bool isClaimStagingPeriodOver,
+            uint256 epochNumber,
+            Machine.Hash stagedPostEpochMachineStateHash,
+            bytes32 stagedPostEpochOutputsMerkleRoot
+        )
+    {
+        epochNumber = _epochNumber;
+        isTournamentResultStaged = _isTournamentResultStaged;
+        if (_isTournamentResultStaged) {
+            isClaimStagingPeriodOver = ((block.number - _stagingBlockNumber) >= _CLAIM_STAGING_PERIOD);
+            stagedPostEpochMachineStateHash = _stagedPostEpochMachineStateHash;
+            stagedPostEpochOutputsMerkleRoot = _stagedPostEpochOutputsMerkleRoot;
+        }
+    }
+
+    function acceptStagedTournamentResult(uint256 epochNumber) external override notForeclosed(_APP_CONTRACT) {
+        // Check tournament settlement
+        require(epochNumber == _epochNumber, IncorrectEpochNumber(epochNumber, _epochNumber));
+
+        // Check whether the tournament result is staged
+        require(_isTournamentResultStaged, TournamentResultNotStaged());
+
+        // Check whether the claim staging period has elapsed
+        {
+            uint256 numberOfBlocksAfterStaging = block.number - _stagingBlockNumber;
+            require(
+                numberOfBlocksAfterStaging >= _CLAIM_STAGING_PERIOD,
+                ClaimStagingPeriodNotOverYet(numberOfBlocksAfterStaging, _CLAIM_STAGING_PERIOD)
+            );
+        }
+
+        // Get staged tournament result
+        Machine.Hash finalMachineStateHash = _stagedPostEpochMachineStateHash;
+        bytes32 outputsMerkleRoot = _stagedPostEpochOutputsMerkleRoot;
 
         // Seal current accumulating epoch, save settled output tree and machine state hash
         _epochNumber++;
@@ -137,6 +197,7 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
         _inputIndexUpperBound = _INPUT_BOX.getNumberOfInputs(_APP_CONTRACT);
         _outputsMerkleRoots[outputsMerkleRoot] = true;
         _lastFinalizedMachineStateHash = finalMachineStateHash;
+        _isTournamentResultStaged = false;
 
         // Start new tournament
         _tournament = _TOURNAMENT_FACTORY.instantiate(finalMachineStateHash, this);
@@ -149,8 +210,6 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
             outputsMerkleRoot,
             _tournament
         );
-
-        oldTournament.tryRecoveringBond();
     }
 
     function getCurrentSealedEpoch()
@@ -161,13 +220,23 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
             uint256 epochNumber,
             uint256 inputIndexLowerBound,
             uint256 inputIndexUpperBound,
-            ITournament tournament
+            ITournament tournament,
+            bool isTournamentResultStaged,
+            uint256 stagingBlockNumber,
+            Machine.Hash stagedPostEpochMachineStateHash,
+            bytes32 stagedPostEpochOutputsMerkleRoot
         )
     {
         epochNumber = _epochNumber;
         inputIndexLowerBound = _inputIndexLowerBound;
         inputIndexUpperBound = _inputIndexUpperBound;
         tournament = _tournament;
+        isTournamentResultStaged = _isTournamentResultStaged;
+        if (_isTournamentResultStaged) {
+            stagingBlockNumber = _stagingBlockNumber;
+            stagedPostEpochMachineStateHash = _stagedPostEpochMachineStateHash;
+            stagedPostEpochOutputsMerkleRoot = _stagedPostEpochOutputsMerkleRoot;
+        }
     }
 
     function getInputBox() external view override returns (IInputBox) {
@@ -180,6 +249,10 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
 
     function getTournamentFactory() external view override returns (ITournamentFactory) {
         return _TOURNAMENT_FACTORY;
+    }
+
+    function getClaimStagingPeriod() external view override returns (uint256) {
+        return _CLAIM_STAGING_PERIOD;
     }
 
     function provideMerkleRootOfInput(uint256 inputIndexWithinEpoch, bytes calldata input)

--- a/cartesi-rollups/contracts/src/DaveConsensus.sol
+++ b/cartesi-rollups/contracts/src/DaveConsensus.sol
@@ -49,6 +49,10 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
     /// @notice Deployment block number
     uint256 immutable _DEPLOYMENT_BLOCK_NUMBER = block.number;
 
+    /// @notice The account that is authorized to manage sentry rotations.
+    /// @notice See the `getSentryManager` function.
+    address immutable _SENTRY_MANAGER;
+
     /// @notice The total number of sentries.
     /// @notice See the `getNumberOfSentries` function.
     uint256 immutable _NUM_OF_SENTRIES;
@@ -111,6 +115,7 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
         ITournamentFactory tournamentFactory,
         Machine.Hash initialMachineStateHash,
         uint256 claimStagingPeriod,
+        address sentryManager,
         address[] memory sentries
     ) {
         // Initialize immutable variables
@@ -118,6 +123,7 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
         _APP_CONTRACT = appContract;
         _TOURNAMENT_FACTORY = tournamentFactory;
         _CLAIM_STAGING_PERIOD = claimStagingPeriod;
+        _SENTRY_MANAGER = sentryManager;
         for (uint256 i; i < sentries.length; ++i) {
             address sentry = sentries[i];
             _ensureSentryAddressIsValid(sentry);
@@ -273,6 +279,21 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
         );
     }
 
+    function rotateSentry(address currentSentry, address newSentry)
+        external
+        override
+        onlySentryManager
+        notForeclosed(_APP_CONTRACT)
+    {
+        uint256 sentryId = getSentryId(currentSentry);
+        require(sentryId > 0, CannotRotateNonSentry(currentSentry));
+        _ensureSentryAddressIsValid(newSentry);
+        _sentryId[currentSentry] = 0;
+        _sentryId[newSentry] = sentryId;
+        _sentryById[sentryId] = newSentry;
+        emit SentryRotation(sentryId, currentSentry, newSentry);
+    }
+
     function getCurrentSealedEpoch()
         external
         view
@@ -314,6 +335,10 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
 
     function getClaimStagingPeriod() external view override returns (uint256) {
         return _CLAIM_STAGING_PERIOD;
+    }
+
+    function getSentryManager() external view override returns (address) {
+        return _SENTRY_MANAGER;
     }
 
     function getNumberOfSentries() external view override returns (uint256) {
@@ -418,6 +443,11 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
         _;
     }
 
+    modifier onlySentryManager() {
+        _ensureCallerIsSentryManager();
+        _;
+    }
+
     function _ensureAppContractIsValid(address appContract) internal view {
         require(_APP_CONTRACT == appContract, ApplicationMismatch(_APP_CONTRACT, appContract));
     }
@@ -426,5 +456,10 @@ contract DaveConsensus is IDaveConsensus, ERC165, ApplicationChecker {
         require(sentry != address(0), ZeroSentryAddress());
         uint256 sentryId = getSentryId(sentry);
         require(sentryId == 0, DuplicatedSentryAddress(sentryId, sentry));
+    }
+
+    function _ensureCallerIsSentryManager() internal view {
+        address caller = msg.sender;
+        require(caller == _SENTRY_MANAGER, CallerIsNotSentryManager(caller));
     }
 }

--- a/cartesi-rollups/contracts/src/DaveConsensus.sol
+++ b/cartesi-rollups/contracts/src/DaveConsensus.sol
@@ -1,7 +1,7 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.30;
 
 import {ERC165} from "@openzeppelin-contracts-5.2.0/utils/introspection/ERC165.sol";
 import {IERC165} from "@openzeppelin-contracts-5.2.0/utils/introspection/IERC165.sol";

--- a/cartesi-rollups/contracts/src/IDaveAppFactory.sol
+++ b/cartesi-rollups/contracts/src/IDaveAppFactory.sol
@@ -8,11 +8,12 @@ import {IApplication} from "cartesi-rollups-contracts-3.0.0/src/dapp/IApplicatio
 import {IApplicationFactoryErrors} from "cartesi-rollups-contracts-3.0.0/src/dapp/IApplicationFactoryErrors.sol";
 
 import {IDaveConsensus} from "./IDaveConsensus.sol";
+import {ISentryErrors} from "./ISentryErrors.sol";
 
 /// @title Dave-App Pair Factory
 /// @notice Allows anyone to reliably deploy an application
 /// validated by a newly-deployed `IDaveConsensus` contract.
-interface IDaveAppFactory is IApplicationFactoryErrors {
+interface IDaveAppFactory is IApplicationFactoryErrors, ISentryErrors {
     /// @notice A Dave-App pair was created.
     /// @param appContract The application contract
     /// @param daveConsensus The Dave consensus contract
@@ -21,13 +22,23 @@ interface IDaveAppFactory is IApplicationFactoryErrors {
     /// @notice Deploy a new Dave-App pair deterministically.
     /// @param templateHash The application template hash
     /// @param claimStagingPeriod The claim staging period
+    /// @param sentries The array of sentries
     /// @param withdrawalConfig The withdrawal configuration
     /// @param salt A 32-byte value used to add entropy to the addresses
     /// @return appContract The application contract
     /// @return daveConsensus The Dave consensus contract
+    /// @dev May raise `ZeroSentryAddress` and `DuplicatedSentryAddress` errors,
+    /// if the sentry array contains a zero or duplicated address, respectively.
+    /// If an empty sentries array is provided, then epochs only settle
+    /// after tournament results are staged for `claimStagingPeriod` blocks.
+    /// If a non-empty sentries array is provided, then the claim staging period
+    /// serves as a fallback if not all sentries agree with the tournament result,
+    /// which should give the guardian enough time to foreclose the application
+    /// if the disagreement stems from a bug on PRT.
     function newDaveApp(
         bytes32 templateHash,
         uint256 claimStagingPeriod,
+        address[] calldata sentries,
         WithdrawalConfig calldata withdrawalConfig,
         bytes32 salt
     ) external returns (IApplication appContract, IDaveConsensus daveConsensus);
@@ -35,6 +46,7 @@ interface IDaveAppFactory is IApplicationFactoryErrors {
     /// @notice Calculate the address of a Dave-App pair.
     /// @param templateHash The application template hash
     /// @param claimStagingPeriod The claim staging period
+    /// @param sentries The array of sentries
     /// @param withdrawalConfig The withdrawal configuration
     /// @param salt A 32-byte value used to add entropy to the addresses
     /// @return appContractAddress The application contract address
@@ -42,6 +54,7 @@ interface IDaveAppFactory is IApplicationFactoryErrors {
     function calculateDaveAppAddress(
         bytes32 templateHash,
         uint256 claimStagingPeriod,
+        address[] calldata sentries,
         WithdrawalConfig calldata withdrawalConfig,
         bytes32 salt
     ) external view returns (address appContractAddress, address daveConsensusAddress);

--- a/cartesi-rollups/contracts/src/IDaveAppFactory.sol
+++ b/cartesi-rollups/contracts/src/IDaveAppFactory.sol
@@ -11,7 +11,7 @@ import {IDaveConsensus} from "./IDaveConsensus.sol";
 
 /// @title Dave-App Pair Factory
 /// @notice Allows anyone to reliably deploy an application
-/// validated a newly-deployed `IDaveConsensus` contract.
+/// validated by a newly-deployed `IDaveConsensus` contract.
 interface IDaveAppFactory is IApplicationFactoryErrors {
     /// @notice A Dave-App pair was created.
     /// @param appContract The application contract
@@ -20,22 +20,29 @@ interface IDaveAppFactory is IApplicationFactoryErrors {
 
     /// @notice Deploy a new Dave-App pair deterministically.
     /// @param templateHash The application template hash
+    /// @param claimStagingPeriod The claim staging period
     /// @param withdrawalConfig The withdrawal configuration
     /// @param salt A 32-byte value used to add entropy to the addresses
     /// @return appContract The application contract
     /// @return daveConsensus The Dave consensus contract
-    function newDaveApp(bytes32 templateHash, WithdrawalConfig calldata withdrawalConfig, bytes32 salt)
-        external
-        returns (IApplication appContract, IDaveConsensus daveConsensus);
+    function newDaveApp(
+        bytes32 templateHash,
+        uint256 claimStagingPeriod,
+        WithdrawalConfig calldata withdrawalConfig,
+        bytes32 salt
+    ) external returns (IApplication appContract, IDaveConsensus daveConsensus);
 
     /// @notice Calculate the address of a Dave-App pair.
     /// @param templateHash The application template hash
+    /// @param claimStagingPeriod The claim staging period
     /// @param withdrawalConfig The withdrawal configuration
     /// @param salt A 32-byte value used to add entropy to the addresses
     /// @return appContractAddress The application contract address
     /// @return daveConsensusAddress The Dave consensus contract address
-    function calculateDaveAppAddress(bytes32 templateHash, WithdrawalConfig calldata withdrawalConfig, bytes32 salt)
-        external
-        view
-        returns (address appContractAddress, address daveConsensusAddress);
+    function calculateDaveAppAddress(
+        bytes32 templateHash,
+        uint256 claimStagingPeriod,
+        WithdrawalConfig calldata withdrawalConfig,
+        bytes32 salt
+    ) external view returns (address appContractAddress, address daveConsensusAddress);
 }

--- a/cartesi-rollups/contracts/src/IDaveAppFactory.sol
+++ b/cartesi-rollups/contracts/src/IDaveAppFactory.sol
@@ -22,6 +22,7 @@ interface IDaveAppFactory is IApplicationFactoryErrors, ISentryErrors {
     /// @notice Deploy a new Dave-App pair deterministically.
     /// @param templateHash The application template hash
     /// @param claimStagingPeriod The claim staging period
+    /// @param sentryManager The sentry manager address
     /// @param sentries The array of sentries
     /// @param withdrawalConfig The withdrawal configuration
     /// @param salt A 32-byte value used to add entropy to the addresses
@@ -38,6 +39,7 @@ interface IDaveAppFactory is IApplicationFactoryErrors, ISentryErrors {
     function newDaveApp(
         bytes32 templateHash,
         uint256 claimStagingPeriod,
+        address sentryManager,
         address[] calldata sentries,
         WithdrawalConfig calldata withdrawalConfig,
         bytes32 salt
@@ -46,6 +48,7 @@ interface IDaveAppFactory is IApplicationFactoryErrors, ISentryErrors {
     /// @notice Calculate the address of a Dave-App pair.
     /// @param templateHash The application template hash
     /// @param claimStagingPeriod The claim staging period
+    /// @param sentryManager The sentry manager address
     /// @param sentries The array of sentries
     /// @param withdrawalConfig The withdrawal configuration
     /// @param salt A 32-byte value used to add entropy to the addresses
@@ -54,6 +57,7 @@ interface IDaveAppFactory is IApplicationFactoryErrors, ISentryErrors {
     function calculateDaveAppAddress(
         bytes32 templateHash,
         uint256 claimStagingPeriod,
+        address sentryManager,
         address[] calldata sentries,
         WithdrawalConfig calldata withdrawalConfig,
         bytes32 salt

--- a/cartesi-rollups/contracts/src/IDaveAppFactory.sol
+++ b/cartesi-rollups/contracts/src/IDaveAppFactory.sol
@@ -1,7 +1,7 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.30;
 
 import {WithdrawalConfig} from "cartesi-rollups-contracts-3.0.0/src/common/WithdrawalConfig.sol";
 import {IApplication} from "cartesi-rollups-contracts-3.0.0/src/dapp/IApplication.sol";

--- a/cartesi-rollups/contracts/src/IDaveConsensus.sol
+++ b/cartesi-rollups/contracts/src/IDaveConsensus.sol
@@ -71,7 +71,7 @@ interface IDaveConsensus is
     /// @param outputsMerkleRoot the Merkle root hash of the outputs tree
     /// @param tournament the sealed epoch tournament contract
     event EpochSealed(
-        uint256 epochNumber,
+        uint256 indexed epochNumber,
         uint256 inputIndexLowerBound,
         uint256 inputIndexUpperBound,
         Machine.Hash initialMachineStateHash,
@@ -96,7 +96,9 @@ interface IDaveConsensus is
     /// @param stagedPostEpochMachineStateHash The staged post-epoch machine state hash
     /// @param stagedPostEpochOutputsMerkleRoot The staged post-epoch outputs Merkle root
     event EpochStaged(
-        uint256 epochNumber, Machine.Hash stagedPostEpochMachineStateHash, bytes32 stagedPostEpochOutputsMerkleRoot
+        uint256 indexed epochNumber,
+        Machine.Hash stagedPostEpochMachineStateHash,
+        bytes32 stagedPostEpochOutputsMerkleRoot
     );
 
     /// @notice The sentry manager rotated a sentry.

--- a/cartesi-rollups/contracts/src/IDaveConsensus.sol
+++ b/cartesi-rollups/contracts/src/IDaveConsensus.sol
@@ -23,21 +23,27 @@ import {Tree} from "prt-contracts/types/Tree.sol";
 /// which read inputs from the InputBox contract.
 ///
 /// @notice This contract also manages epoch boundaries, which
-/// are defined in terms of block numbers. We represent them
+/// are defined in terms of input indices. We represent them
 /// as intervals of the form [a,b). They are also identified by
 /// incremental numbers that start from 0.
 ///
 /// @notice Off-chain nodes can listen to `EpochSealed` events
 /// to know where epochs start and end, and which epochs have been
 /// settled already and which one is open for challenges still.
-/// Anyone can settle an epoch by calling `settle`.
-/// One can also check if it can be settled by calling `canSettle`.
+/// Anyone can stage a tournament result by calling `stageTournamentResult`.
+/// One can also check if it can be staged by calling `canStageTournamentResult`.
+/// Anyone can settle an epoch by calling `acceptStagedTournamentResult`.
+/// One can also check if it can be settled by calling `canAcceptStagedTournamentResult`.
 ///
 /// @notice At any given time, there is always one sealed epoch.
 /// Prior to it, every epoch has been settled.
 /// After it, the next epoch is accumulating inputs. Once this epoch is settled,
-/// the accumlating epoch will be sealed, and a new
+/// the accumulating epoch will be sealed, and a new
 /// accumulating epoch will be created.
+/// Every sealed epoch has an associated tournament.
+/// Once a tournament is finished, and a winner commitment is declared,
+/// it can then be staged by anyone. After the claim staging period is elapsed,
+/// anyone can settle the epoch by accepting the staged winner commitment.
 ///
 interface IDaveConsensus is IDataProvider, IOutputsMerkleRootValidator, IApplicationChecker, BinaryMerkleTreeErrors {
     /// @notice Consensus contract was created
@@ -62,6 +68,14 @@ interface IDaveConsensus is IDataProvider, IOutputsMerkleRootValidator, IApplica
         ITournament tournament
     );
 
+    /// @notice An epoch was staged
+    /// @param epochNumber the sealed epoch number
+    /// @param stagedPostEpochMachineStateHash The staged post-epoch machine state hash
+    /// @param stagedPostEpochOutputsMerkleRoot The staged post-epoch outputs Merkle root
+    event EpochStaged(
+        uint256 epochNumber, Machine.Hash stagedPostEpochMachineStateHash, bytes32 stagedPostEpochOutputsMerkleRoot
+    );
+
     /// @notice Received epoch number is different from actual
     /// @param received The epoch number received as argument
     /// @param actual The actual epoch number in storage
@@ -69,6 +83,17 @@ interface IDaveConsensus is IDataProvider, IOutputsMerkleRootValidator, IApplica
 
     /// @notice Tournament is not finished yet
     error TournamentNotFinishedYet();
+
+    /// @notice Tournament result is not yet staged
+    error TournamentResultNotStaged();
+
+    /// @notice Tournament result was already staged
+    error TournamentResultAlreadyStaged();
+
+    /// @notice The tournament result was staged but the claim staging period is not over yet.
+    /// @param numberOfBlocksAfterStaging The number of blocks since the claim was staged
+    /// @param claimStagingPeriod The claim staging period, in number of blocks
+    error ClaimStagingPeriodNotOverYet(uint256 numberOfBlocksAfterStaging, uint256 claimStagingPeriod);
 
     /// @notice Hash of received input blob is different from stored on-chain
     /// @param fromReceivedInput Hash of received input blob
@@ -100,11 +125,23 @@ interface IDaveConsensus is IDataProvider, IOutputsMerkleRootValidator, IApplica
     /// @notice Get the tournament factory contract used to instantiate root tournaments.
     function getTournamentFactory() external view returns (ITournamentFactory);
 
-    /// @notice Get the current sealed epoch number, boundaries, and tournament.
-    /// @param epochNumber The epoch number
-    /// @param inputIndexLowerBound The epoch input index (inclusive) lower bound
-    /// @param inputIndexUpperBound The epoch input index (exclusive) upper bound
-    /// @param tournament The tournament that will decide the post-epoch state
+    /// @notice Get the number of base-layer blocks after which a staged claim can be accepted.
+    /// @dev A claim, in the context of PRT, is the winner commitment of a tournament, if there is one.
+    /// Once a tournament finishes, and a winner is declared, anyone can stage the tournament result,
+    /// and, after the claim staging period is elapsed, accept it into finality.
+    function getClaimStagingPeriod() external view returns (uint256);
+
+    /// @notice Get the current sealed epoch number, boundaries, tournament, and staging info.
+    /// @return epochNumber The epoch number
+    /// @return inputIndexLowerBound The epoch input index (inclusive) lower bound
+    /// @return inputIndexUpperBound The epoch input index (exclusive) upper bound
+    /// @return tournament The tournament that will decide the post-epoch state
+    /// @return isTournamentResultStaged Whether the tournament result (if there is one) is staged
+    /// @return stagingBlockNumber The number of the block in which the tournament result was staged
+    /// @return stagedPostEpochMachineStateHash The staged post-epoch machine state hash
+    /// @return stagedPostEpochOutputsMerkleRoot The staged post-epoch outputs Merkle root
+    /// @dev The values of stagingBlockNumber, stagedPostEpochMachineStateHash, and stagedPostEpochOutputsMerkleRoot
+    /// only have meaning if the value of isTournamentResultStaged is true.
     function getCurrentSealedEpoch()
         external
         view
@@ -112,19 +149,61 @@ interface IDaveConsensus is IDataProvider, IOutputsMerkleRootValidator, IApplica
             uint256 epochNumber,
             uint256 inputIndexLowerBound,
             uint256 inputIndexUpperBound,
-            ITournament tournament
+            ITournament tournament,
+            bool isTournamentResultStaged,
+            uint256 stagingBlockNumber,
+            Machine.Hash stagedPostEpochMachineStateHash,
+            bytes32 stagedPostEpochOutputsMerkleRoot
         );
 
-    /// @notice Check whether the current sealed epoch can be settled.
-    /// @return isFinished Whether the current sealed epoch tournament has finished yet
+    /// @notice Check whether the tournament result of the current sealed epoch can be staged.
+    /// @return isFinished Whether the current sealed epoch tournament is finished
+    /// @return isTournamentResultStaged Whether the tournament result (if there is one) is staged
     /// @return epochNumber The current sealed epoch number
-    /// @return winnerCommitment If the tournament has finished, the winning commitment
-    function canSettle() external view returns (bool isFinished, uint256 epochNumber, Tree.Node winnerCommitment);
+    /// @return winnerCommitment If the tournament has finished, the winner commitment
+    /// @return winnerPostEpochMachineStateHash If the tournament has finished, the winner post-epoch machine state hash
+    /// @dev Validators should only call `stageTournamentResult` if isFinished is true and isTournamentResultStaged is false.
+    function canStageTournamentResult()
+        external
+        view
+        returns (
+            bool isFinished,
+            bool isTournamentResultStaged,
+            uint256 epochNumber,
+            Tree.Node winnerCommitment,
+            Machine.Hash winnerPostEpochMachineStateHash
+        );
 
-    /// @notice Settle the current sealed epoch.
+    /// @notice Stage the tournament result of the current sealed epoch.
     /// @param epochNumber The current sealed epoch number (used to avoid race conditions)
     /// @param outputsMerkleRoot The post-epoch outputs Merkle root (used to validate outputs)
     /// @param proof The bottom-up Merkle proof of the outputs Merkle root in the final machine state
+    /// @dev On success, emits an `EpochStaged` event.
+    function stageTournamentResult(uint256 epochNumber, bytes32 outputsMerkleRoot, bytes32[] calldata proof) external;
+
+    /// @notice Check whether the staged tournament result of the current sealed epoch can be accepted.
+    /// @return isTournamentResultStaged Whether the tournament result (if there is one) is staged
+    /// @return isClaimStagingPeriodOver Whether the claim staging period is over
+    /// @return epochNumber The current sealed epoch number
+    /// @return stagedPostEpochMachineStateHash If the tournament result is staged, the staged post-epoch machine state hash
+    /// @return stagedPostEpochOutputsMerkleRoot If the tournament result is staged, the staged post-epoch outputs Merkle root
+    /// @dev Validators should only call `acceptStagedTournamentResult` if both isTournamentResultStaged
+    /// and isClaimStagingPeriodOver are true. Be also mindful that isClaimStagingPeriodOver,
+    /// stagedPostEpochMachineStateHash, and stagedPostEpochOutputsMerkleRoot only have any meaning
+    /// if isTournamentResultStaged is true.
+    function canAcceptStagedTournamentResult()
+        external
+        view
+        returns (
+            bool isTournamentResultStaged,
+            bool isClaimStagingPeriodOver,
+            uint256 epochNumber,
+            Machine.Hash stagedPostEpochMachineStateHash,
+            bytes32 stagedPostEpochOutputsMerkleRoot
+        );
+
+    /// @notice Accept the staged tournament result of the current sealed epoch.
+    /// @param epochNumber The current sealed epoch number (used to avoid race conditions)
     /// @dev On success, emits an `EpochSealed` event.
-    function settle(uint256 epochNumber, bytes32 outputsMerkleRoot, bytes32[] calldata proof) external;
+    function acceptStagedTournamentResult(uint256 epochNumber) external;
 }

--- a/cartesi-rollups/contracts/src/IDaveConsensus.sol
+++ b/cartesi-rollups/contracts/src/IDaveConsensus.sol
@@ -1,7 +1,7 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.30;
 
 import {BinaryMerkleTreeErrors} from "cartesi-rollups-contracts-3.0.0/src/common/BinaryMerkleTreeErrors.sol";
 import {

--- a/cartesi-rollups/contracts/src/IDaveConsensus.sol
+++ b/cartesi-rollups/contracts/src/IDaveConsensus.sol
@@ -17,6 +17,8 @@ import {ITournamentFactory} from "prt-contracts/ITournamentFactory.sol";
 import {Machine} from "prt-contracts/types/Machine.sol";
 import {Tree} from "prt-contracts/types/Tree.sol";
 
+import {ISentryErrors} from "./ISentryErrors.sol";
+
 /// @notice Consensus contract with Dave tournaments.
 ///
 /// @notice This contract validates only one application,
@@ -32,6 +34,8 @@ import {Tree} from "prt-contracts/types/Tree.sol";
 /// settled already and which one is open for challenges still.
 /// Anyone can stage a tournament result by calling `stageTournamentResult`.
 /// One can also check if it can be staged by calling `canStageTournamentResult`.
+/// Sentries can submit claims for the post-epoch machine state hash
+/// in order to speed up epoch settlement (by skipping the claim staging period).
 /// Anyone can settle an epoch by calling `acceptStagedTournamentResult`.
 /// One can also check if it can be settled by calling `canAcceptStagedTournamentResult`.
 ///
@@ -43,9 +47,16 @@ import {Tree} from "prt-contracts/types/Tree.sol";
 /// Every sealed epoch has an associated tournament.
 /// Once a tournament is finished, and a winner commitment is declared,
 /// it can then be staged by anyone. After the claim staging period is elapsed,
+/// or all sentries (if there is any) agree with the staged tournament result,
 /// anyone can settle the epoch by accepting the staged winner commitment.
 ///
-interface IDaveConsensus is IDataProvider, IOutputsMerkleRootValidator, IApplicationChecker, BinaryMerkleTreeErrors {
+interface IDaveConsensus is
+    IDataProvider,
+    IOutputsMerkleRootValidator,
+    IApplicationChecker,
+    BinaryMerkleTreeErrors,
+    ISentryErrors
+{
     /// @notice Consensus contract was created
     /// @param inputBox the input box contract
     /// @param appContract the application contract
@@ -66,6 +77,18 @@ interface IDaveConsensus is IDataProvider, IOutputsMerkleRootValidator, IApplica
         Machine.Hash initialMachineStateHash,
         bytes32 outputsMerkleRoot,
         ITournament tournament
+    );
+
+    /// @notice A sentry has claimed the post-epoch machine state hash.
+    /// @param epochNumber The epoch number
+    /// @param sentryId The sentry ID
+    /// @param sentry The sentry address
+    /// @param postEpochMachineStateHash The post-epoch machine state hash
+    event SentryClaim(
+        uint256 indexed epochNumber,
+        uint256 indexed sentryId,
+        address indexed sentry,
+        Machine.Hash postEpochMachineStateHash
     );
 
     /// @notice An epoch was staged
@@ -113,6 +136,17 @@ interface IDaveConsensus is IDataProvider, IOutputsMerkleRootValidator, IApplica
     /// @param received Received application address
     error ApplicationMismatch(address expected, address received);
 
+    /// @notice This error is raised whenever the `submitSentryClaim`
+    /// function is called by someone who is not a sentry.
+    /// @param caller The caller address
+    error CallerIsNotSentry(address caller);
+
+    /// @notice This error is raised whenever a sentry attempts to call the
+    /// `submitSentryClaim` function twice for the same epoch.
+    /// @param epochNumber The epoch number
+    /// @param sentryId The sentry ID
+    error SentryAlreadyClaimed(uint256 epochNumber, uint256 sentryId);
+
     /// @notice Get the number of base-layer block in which the contract was deployed.
     function getDeploymentBlockNumber() external view returns (uint256);
 
@@ -127,9 +161,43 @@ interface IDaveConsensus is IDataProvider, IOutputsMerkleRootValidator, IApplica
 
     /// @notice Get the number of base-layer blocks after which a staged claim can be accepted.
     /// @dev A claim, in the context of PRT, is the winner commitment of a tournament, if there is one.
-    /// Once a tournament finishes, and a winner is declared, anyone can stage the tournament result,
-    /// and, after the claim staging period is elapsed, accept it into finality.
+    /// Once a tournament finishes, and a winner is declared, anyone can stage the tournament result.
+    /// After all sentries agree with the staged claim or after the claim staging period is elapsed,
+    /// anyone can accept the staged claim into finality. If there are no sentries, then acceptance
+    /// can only occur after the claim staging period is elapsed.
     function getClaimStagingPeriod() external view returns (uint256);
+
+    /// @notice Get the number of sentries.
+    /// @dev This number can be zero, that is, there are no sentries.
+    function getNumberOfSentries() external view returns (uint256);
+
+    /// @notice Get the ID of a sentry.
+    /// @param sentry The sentry address
+    /// @dev Sentries are assigned IDs between 1 and `N`, the total number of sentries.
+    /// @dev Non-sentries are assigned to ID zero.
+    function getSentryId(address sentry) external view returns (uint256);
+
+    /// @notice Get the address of a sentry by its ID.
+    /// @param sentryId The sentry ID
+    /// @dev Sentry IDs range from 1 to `N`, the total number of sentries.
+    /// @dev Valid IDs do not map to address zero.
+    /// @dev Invalid IDs map to address zero.
+    function getSentryById(uint256 sentryId) external view returns (address);
+
+    /// @notice Check whether a sentry has claimed any post-epoch machine state in a given epoch.
+    /// @param epochNumber The epoch number
+    /// @param sentryId The sentry ID
+    /// @dev You can obtain the ID of a sentry by its address through the `getSentryId` function
+    /// or the address of a sentry by its ID through the `getSentryById` function.
+    function hasSentryClaimedInEpoch(uint256 epochNumber, uint256 sentryId) external view returns (bool);
+
+    /// @notice Get the number of sentries that have claimed a given post-epoch machine state in a given epoch.
+    /// @param epochNumber The epoch number
+    /// @param postEpochMachineStateHash The post-epoch machine state hash
+    function getSentryClaimCount(uint256 epochNumber, Machine.Hash postEpochMachineStateHash)
+        external
+        view
+        returns (uint256);
 
     /// @notice Get the current sealed epoch number, boundaries, tournament, and staging info.
     /// @return epochNumber The epoch number
@@ -181,21 +249,32 @@ interface IDaveConsensus is IDataProvider, IOutputsMerkleRootValidator, IApplica
     /// @dev On success, emits an `EpochStaged` event.
     function stageTournamentResult(uint256 epochNumber, bytes32 outputsMerkleRoot, bytes32[] calldata proof) external;
 
+    /// @notice As a sentry, claim the post-epoch machine state hash for the current sealed epoch.
+    /// If all sentries claim the same post-epoch machine state hash as the staged tournament result,
+    /// then the claim staging period is skipped entirely, potentially shortening the finality delay.
+    /// Note that this skipping is only possible if the consensus has at least one sentry.
+    /// @param epochNumber The current sealed epoch number (used to avoid race conditions)
+    /// @param postEpochMachineStateHash The post-epoch machine state hash
+    /// @dev On success, emits a `SentryClaim` event.
+    function submitSentryClaim(uint256 epochNumber, Machine.Hash postEpochMachineStateHash) external;
+
     /// @notice Check whether the staged tournament result of the current sealed epoch can be accepted.
     /// @return isTournamentResultStaged Whether the tournament result (if there is one) is staged
+    /// @return doAllSentriesAgreeWithStagedTournamentResult Whether all sentries agree with staged tournament result
     /// @return isClaimStagingPeriodOver Whether the claim staging period is over
     /// @return epochNumber The current sealed epoch number
     /// @return stagedPostEpochMachineStateHash If the tournament result is staged, the staged post-epoch machine state hash
     /// @return stagedPostEpochOutputsMerkleRoot If the tournament result is staged, the staged post-epoch outputs Merkle root
-    /// @dev Validators should only call `acceptStagedTournamentResult` if both isTournamentResultStaged
-    /// and isClaimStagingPeriodOver are true. Be also mindful that isClaimStagingPeriodOver,
-    /// stagedPostEpochMachineStateHash, and stagedPostEpochOutputsMerkleRoot only have any meaning
-    /// if isTournamentResultStaged is true.
+    /// @dev Validators should only call `acceptStagedTournamentResult` if the Boolean expression isTournamentResultStaged
+    /// AND (doAllSentriesAgreeWithStagedTournamentResult OR isClaimStagingPeriodOver) is true. Be also mindful that
+    /// doAllSentriesAgreeWithStagedTournamentResult, isClaimStagingPeriodOver, stagedPostEpochMachineStateHash, and
+    /// stagedPostEpochOutputsMerkleRoot only have any meaning if isTournamentResultStaged is true.
     function canAcceptStagedTournamentResult()
         external
         view
         returns (
             bool isTournamentResultStaged,
+            bool doAllSentriesAgreeWithStagedTournamentResult,
             bool isClaimStagingPeriodOver,
             uint256 epochNumber,
             Machine.Hash stagedPostEpochMachineStateHash,

--- a/cartesi-rollups/contracts/src/IDaveConsensus.sol
+++ b/cartesi-rollups/contracts/src/IDaveConsensus.sol
@@ -99,6 +99,17 @@ interface IDaveConsensus is
         uint256 epochNumber, Machine.Hash stagedPostEpochMachineStateHash, bytes32 stagedPostEpochOutputsMerkleRoot
     );
 
+    /// @notice The sentry manager rotated a sentry.
+    /// @param sentryId The sentry ID
+    /// @param oldSentry The old sentry address
+    /// @param newSentry The new sentry address
+    /// @dev It is guaranteed that, in the instant right before the rotation,
+    /// `getSentryId(oldSentry) == sentryId`, `getSentryId(newSentry) == 0`, and `getSentryById(sentryId) == oldSentry`.
+    /// And, in the instant right after the rotation, it is also guaranteed that
+    /// `getSentryId(oldSentry) == 0`, `getSentryId(newSentry) == sentryId`, and `getSentryById(sentryId) == newSentry`.
+    /// Furthermore, the number of sentries is unchanged all other sentries keep their IDs and addresses.
+    event SentryRotation(uint256 indexed sentryId, address indexed oldSentry, address indexed newSentry);
+
     /// @notice Received epoch number is different from actual
     /// @param received The epoch number received as argument
     /// @param actual The actual epoch number in storage
@@ -147,6 +158,16 @@ interface IDaveConsensus is
     /// @param sentryId The sentry ID
     error SentryAlreadyClaimed(uint256 epochNumber, uint256 sentryId);
 
+    /// @notice This error is raised whenever the `rotateSentry`
+    /// function is called by someone who is not the sentry manager.
+    /// @param caller The caller address
+    error CallerIsNotSentryManager(address caller);
+
+    /// @notice This error is raised whenever the `rotateSentry`
+    /// function is called with a non-sentry address as `currentSentry`.
+    /// @param nonSentry The non-sentry address
+    error CannotRotateNonSentry(address nonSentry);
+
     /// @notice Get the number of base-layer block in which the contract was deployed.
     function getDeploymentBlockNumber() external view returns (uint256);
 
@@ -170,6 +191,10 @@ interface IDaveConsensus is
     /// @notice Get the number of sentries.
     /// @dev This number can be zero, that is, there are no sentries.
     function getNumberOfSentries() external view returns (uint256);
+
+    /// @notice Get the sentry manager address.
+    /// @dev The sentry manager is the only one capable of rotating sentries.
+    function getSentryManager() external view returns (address);
 
     /// @notice Get the ID of a sentry.
     /// @param sentry The sentry address
@@ -198,6 +223,22 @@ interface IDaveConsensus is
         external
         view
         returns (uint256);
+
+    /// @notice As a sentry manager, rotate a sentry.
+    /// @param currentSentry The current sentry address
+    /// @param newSentry The new sentry address that will inherit the current sentry's ID
+    /// @dev This action can be useful whenever a sentry account is compromised.
+    /// A compromised sentry may either purposefully submit false post-epoch machine state hashes
+    /// or drain the funds from the sentry account. In either case, the epoch settlement is delayed
+    /// by the claim staging period, which is undesired for application users and maintainers.
+    /// In those cases, the sentry manager can rotate the address of the compromised sentry slot,
+    /// ensuring epochs settle earlier in the happy path through sentry claims.
+    /// If a sentry has already claimed in the current sealed epoch, then rotating their address
+    /// will not erase their claim. Rather, rotation only updates the address that is authorized
+    /// to claim for that sentry slot. So, if that sentry slot has already placed a claim, then the
+    /// new sentry will only be able to submit a claim for the next epoch.
+    /// On success, emits a `SentryRotation` event.
+    function rotateSentry(address currentSentry, address newSentry) external;
 
     /// @notice Get the current sealed epoch number, boundaries, tournament, and staging info.
     /// @return epochNumber The epoch number

--- a/cartesi-rollups/contracts/src/ISentryErrors.sol
+++ b/cartesi-rollups/contracts/src/ISentryErrors.sol
@@ -1,7 +1,7 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.30;
 
 interface ISentryErrors {
     /// @notice This error is raised either when one tries to deploy a DaveConsensus

--- a/cartesi-rollups/contracts/src/ISentryErrors.sol
+++ b/cartesi-rollups/contracts/src/ISentryErrors.sol
@@ -1,0 +1,20 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+pragma solidity ^0.8.8;
+
+interface ISentryErrors {
+    /// @notice This error is raised either when one tries to deploy a DaveConsensus
+    /// contract or when the sentry manager tries to rotate a sentry. This is forbidden
+    /// because the zero address is reserved as a sentinel value for non-sentries (when
+    /// calling the `getSentryById` function with an invalid sentry ID).
+    error ZeroSentryAddress();
+
+    /// @notice This error is raised either when one tries to deploy a DaveConsensus
+    /// contract or when the sentry manager tries to rotate a sentry. This is forbidden
+    /// because each sentry address should be assigned a single unique sentry ID (which
+    /// can be retrieved by calling the `getSentryId` function with the sentry address).
+    /// @param sentryId The sentry ID
+    /// @param sentry The sentry address
+    error DuplicatedSentryAddress(uint256 sentryId, address sentry);
+}

--- a/cartesi-rollups/contracts/test/DaveAppFactory.t.sol
+++ b/cartesi-rollups/contracts/test/DaveAppFactory.t.sol
@@ -46,6 +46,7 @@ import {Tree} from "prt-contracts/types/Tree.sol";
 import {DaveAppFactory} from "src/DaveAppFactory.sol";
 import {IDaveAppFactory} from "src/IDaveAppFactory.sol";
 import {IDaveConsensus} from "src/IDaveConsensus.sol";
+import {ISentryErrors} from "src/ISentryErrors.sol";
 
 library LibExternalBinaryKeccak256MerkleTree {
     using LibBinaryMerkleTree for bytes32[];
@@ -89,17 +90,18 @@ contract DaveAppFactoryTest is Test {
     function testNewDaveApp(
         bytes32 templateHash,
         uint64 claimStagingPeriod,
+        address[] calldata sentries,
         WithdrawalConfig calldata withdrawalConfig,
         bytes32 salt
     ) external {
         _randomizeBlockNumber(claimStagingPeriod);
 
         (address precalculatedAppContractAddress, address precalculatedDaveConsensusAddress) =
-            _daveAppFactory.calculateDaveAppAddress(templateHash, claimStagingPeriod, withdrawalConfig, salt);
+            _daveAppFactory.calculateDaveAppAddress(templateHash, claimStagingPeriod, sentries, withdrawalConfig, salt);
 
         vm.recordLogs();
 
-        try _daveAppFactory.newDaveApp(templateHash, claimStagingPeriod, withdrawalConfig, salt) returns (
+        try _daveAppFactory.newDaveApp(templateHash, claimStagingPeriod, sentries, withdrawalConfig, salt) returns (
             IApplication appContract, IDaveConsensus daveConsensus
         ) {
             Vm.Log[] memory logs = vm.getRecordedLogs();
@@ -116,10 +118,14 @@ contract DaveAppFactoryTest is Test {
                 "calculateDaveAppAddress(...)[1] != newDaveApp(...)[1]"
             );
 
-            _testNewDaveAppSuccess(templateHash, claimStagingPeriod, withdrawalConfig, appContract, daveConsensus, logs);
+            _testNewDaveAppSuccess(
+                templateHash, claimStagingPeriod, sentries, withdrawalConfig, appContract, daveConsensus, logs
+            );
 
             (precalculatedAppContractAddress, precalculatedDaveConsensusAddress) =
-                _daveAppFactory.calculateDaveAppAddress(templateHash, claimStagingPeriod, withdrawalConfig, salt);
+                _daveAppFactory.calculateDaveAppAddress(
+                    templateHash, claimStagingPeriod, sentries, withdrawalConfig, salt
+                );
 
             assertEq(
                 precalculatedAppContractAddress,
@@ -133,12 +139,12 @@ contract DaveAppFactoryTest is Test {
                 "calculateDaveAppAddress(...)[1] != newDaveApp(...)[1]"
             );
         } catch (bytes memory errorData) {
-            _testNewDaveAppFailure(withdrawalConfig, errorData);
+            _testNewDaveAppFailure(sentries, withdrawalConfig, errorData);
             return;
         }
 
         // Cannot deploy an application with the same salt twice
-        try _daveAppFactory.newDaveApp(templateHash, claimStagingPeriod, withdrawalConfig, salt) {
+        try _daveAppFactory.newDaveApp(templateHash, claimStagingPeriod, sentries, withdrawalConfig, salt) {
             revert("second deterministic deployment did not revert");
         } catch (bytes memory errorData) {
             assertEq(
@@ -150,6 +156,7 @@ contract DaveAppFactoryTest is Test {
     function testStageAndAcceptTournamentResult(
         bytes32 templateHash,
         uint64 claimStagingPeriod,
+        address[] calldata sentries,
         WithdrawalConfig calldata withdrawalConfig,
         bytes32 salt,
         bytes32 outputsMerkleRoot,
@@ -162,7 +169,7 @@ contract DaveAppFactoryTest is Test {
 
         vm.assumeNoRevert();
         (appContract, daveConsensus) =
-            _daveAppFactory.newDaveApp(templateHash, claimStagingPeriod, withdrawalConfig, salt);
+            _daveAppFactory.newDaveApp(templateHash, claimStagingPeriod, sentries, withdrawalConfig, salt);
 
         bytes[] memory inputs = new bytes[](inputPayloads.length);
 
@@ -285,7 +292,7 @@ contract DaveAppFactoryTest is Test {
             bool val1;
             uint256 val2;
 
-            (val1,, val2,,) = daveConsensus.canAcceptStagedTournamentResult();
+            (val1,,, val2,,) = daveConsensus.canAcceptStagedTournamentResult();
 
             assertFalse(val1); // isTournamentResultStaged
             assertEq(val2, 0); // epochNumber
@@ -352,7 +359,7 @@ contract DaveAppFactoryTest is Test {
             bool val1;
             uint256 val2;
 
-            (val1,, val2,,) = daveConsensus.canAcceptStagedTournamentResult();
+            (val1,,, val2,,) = daveConsensus.canAcceptStagedTournamentResult();
 
             assertFalse(val1); // isTournamentResultStaged
             assertEq(val2, 0); // epochNumber
@@ -472,17 +479,19 @@ contract DaveAppFactoryTest is Test {
         {
             bool val1;
             bool val2;
-            uint256 val3;
-            Machine.Hash val4;
-            bytes32 val5;
+            bool val3;
+            uint256 val4;
+            Machine.Hash val5;
+            bytes32 val6;
 
-            (val1, val2, val3, val4, val5) = daveConsensus.canAcceptStagedTournamentResult();
+            (val1, val2, val3, val4, val5, val6) = daveConsensus.canAcceptStagedTournamentResult();
 
             assertTrue(val1); // isTournamentResultStaged
-            assertEq(val2, claimStagingPeriod == 0); // isClaimStagingPeriodOver
-            assertEq(val3, 0); // epochNumber
-            assertEq(Machine.Hash.unwrap(val4), machineMerkleRoot);
-            assertEq(val5, outputsMerkleRoot);
+            assertFalse(val2); // doAllSentriesAgreeWithStagedTournamentResult
+            assertEq(val3, claimStagingPeriod == 0); // isClaimStagingPeriodOver
+            assertEq(val4, 0); // epochNumber
+            assertEq(Machine.Hash.unwrap(val5), machineMerkleRoot);
+            assertEq(val6, outputsMerkleRoot);
         }
 
         assertEq(daveConsensus.getLastFinalizedMachineMerkleRoot(address(appContract)), bytes32(0));
@@ -500,6 +509,17 @@ contract DaveAppFactoryTest is Test {
             vm.expectRevert(_encodeClaimStagingPeriodNotOverYet(numberOfBlocksAfterStaging, claimStagingPeriod));
             vm.prank(vm.randomAddress());
             daveConsensus.acceptStagedTournamentResult(0);
+        }
+
+        // If there is at least one sentry, at random decide to submit sentry claims
+        // corroborating with the staged tournament result
+        uint256 numOfSentries = daveConsensus.getNumberOfSentries();
+        uint256[] memory sentryIds = _getShuffledSentryIds(numOfSentries);
+        uint256 numOfClaims = vm.randomUint(0, numOfSentries);
+        bool doAllSentriesAgreeWithStagedTournamentResult = (numOfSentries > 0) && (numOfClaims == numOfSentries);
+        for (uint256 i; i < numOfClaims; ++i) {
+            _submitSentryClaim(appContract, daveConsensus, 0, sentryIds[i], Machine.Hash.wrap(machineMerkleRoot));
+            _attemptSentryClaimResubmission(daveConsensus, 0, sentryIds[vm.randomUint(0, i)]);
         }
 
         vm.roll(vm.randomUint(stagingBlockNumber + claimStagingPeriod, type(uint64).max));
@@ -548,17 +568,19 @@ contract DaveAppFactoryTest is Test {
         {
             bool val1;
             bool val2;
-            uint256 val3;
-            Machine.Hash val4;
-            bytes32 val5;
+            bool val3;
+            uint256 val4;
+            Machine.Hash val5;
+            bytes32 val6;
 
-            (val1, val2, val3, val4, val5) = daveConsensus.canAcceptStagedTournamentResult();
+            (val1, val2, val3, val4, val5, val6) = daveConsensus.canAcceptStagedTournamentResult();
 
             assertTrue(val1); // isTournamentResultStaged
-            assertTrue(val2); // isClaimStagingPeriodOver
-            assertEq(val3, 0); // epochNumber
-            assertEq(Machine.Hash.unwrap(val4), machineMerkleRoot);
-            assertEq(val5, outputsMerkleRoot);
+            assertEq(val2, doAllSentriesAgreeWithStagedTournamentResult);
+            assertTrue(val3); // isClaimStagingPeriodOver
+            assertEq(val4, 0); // epochNumber
+            assertEq(Machine.Hash.unwrap(val5), machineMerkleRoot);
+            assertEq(val6, outputsMerkleRoot);
         }
 
         assertEq(daveConsensus.getLastFinalizedMachineMerkleRoot(address(appContract)), bytes32(0));
@@ -615,7 +637,7 @@ contract DaveAppFactoryTest is Test {
             bool val1;
             uint256 val2;
 
-            (val1,, val2,,) = daveConsensus.canAcceptStagedTournamentResult();
+            (val1,,, val2,,) = daveConsensus.canAcceptStagedTournamentResult();
 
             assertFalse(val1); // isTournamentResultStaged
             assertEq(val2, 1); // epochNumber
@@ -699,6 +721,23 @@ contract DaveAppFactoryTest is Test {
         revert("Successful staging");
     }
 
+    /// @notice This function is used to simulate a foreclosure and a sentry claim.
+    /// If the claim succeeds, then the function reverts with error message "Successful claim".
+    /// If the claim fails, then the function propagates the error from the DaveConsensus contract.
+    function simulateForeclosureAndSentryClaim(
+        IApplication appContract,
+        IDaveConsensus daveConsensus,
+        uint256 epochNumber,
+        address sentry,
+        Machine.Hash postEpochMachineStateHash
+    ) external {
+        vm.prank(appContract.getGuardian());
+        appContract.foreclose();
+        vm.prank(sentry);
+        daveConsensus.submitSentryClaim(epochNumber, postEpochMachineStateHash);
+        revert("Successful claim");
+    }
+
     /// @notice This function is used to simulate a foreclosure and a tournament-result acceptance.
     /// If the acceptance succeeds, then the function reverts with error message "Successful acceptance".
     /// If the acceptance fails, then the function propagates the error from the DaveConsensus contract.
@@ -717,6 +756,7 @@ contract DaveAppFactoryTest is Test {
     function _testNewDaveAppSuccess(
         bytes32 templateHash,
         uint64 claimStagingPeriod,
+        address[] calldata sentries,
         WithdrawalConfig calldata withdrawalConfig,
         IApplication appContract,
         IDaveConsensus daveConsensus,
@@ -921,6 +961,7 @@ contract DaveAppFactoryTest is Test {
         assertEq(address(daveConsensus.getApplicationContract()), address(appContract));
         assertEq(address(daveConsensus.getTournamentFactory()), address(_tournamentFactory));
         assertEq(daveConsensus.getClaimStagingPeriod(), claimStagingPeriod);
+        assertEq(_getSentries(daveConsensus), sentries);
         assertEq(daveConsensus.getDeploymentBlockNumber(), vm.getBlockNumber());
         assertTrue(daveConsensus.supportsInterface(type(IERC165).interfaceId));
         assertTrue(daveConsensus.supportsInterface(type(IOutputsMerkleRootValidator).interfaceId));
@@ -965,14 +1006,34 @@ contract DaveAppFactoryTest is Test {
             bytes memory input = vm.randomBytes(inputLength);
             assertEq(daveConsensus.provideMerkleRootOfInput(inputIndexWithinBounds, input), bytes32(0));
         }
+
+        assertEq(daveConsensus.getSentryId(address(0)), 0);
+        assertEq(daveConsensus.getSentryId(_randomAddressNotIn(sentries)), 0);
+        assertEq(daveConsensus.getSentryById(0), address(0));
+        assertEq(daveConsensus.getSentryById(vm.randomUint(sentries.length + 1, type(uint256).max)), address(0));
+        assertFalse(daveConsensus.hasSentryClaimedInEpoch(vm.randomUint(), vm.randomUint()));
+        assertEq(daveConsensus.getSentryClaimCount(vm.randomUint(), Machine.Hash.wrap(bytes32(vm.randomUint()))), 0);
     }
 
-    function _testNewDaveAppFailure(WithdrawalConfig calldata withdrawalConfig, bytes memory errorData) internal pure {
+    function _testNewDaveAppFailure(
+        address[] calldata sentries,
+        WithdrawalConfig calldata withdrawalConfig,
+        bytes memory errorData
+    ) internal pure {
         (bool isValidError, bytes32 errorSelector, bytes memory errorArgs) = errorData.consumeBytes4();
         assertTrue(isValidError, "Expected error to contain a 4-byte selector");
         if (errorSelector == IApplicationFactoryErrors.InvalidWithdrawalConfig.selector) {
             assertEq(errorArgs, abi.encode(withdrawalConfig), "Expected withdrawal configs to match");
             assertFalse(withdrawalConfig.isValid(), "Expected withdrawal config to be invalid");
+        } else if (errorSelector == ISentryErrors.ZeroSentryAddress.selector) {
+            assertEq(errorArgs, abi.encode());
+            assertTrue(_contains(sentries, address(0)), "Expected sentries array to have the zero address");
+        } else if (errorSelector == ISentryErrors.DuplicatedSentryAddress.selector) {
+            (uint256 sentryId, address sentry) = abi.decode(errorArgs, (uint256, address));
+            assertGe(sentryId, 1, "Expected sentry ID >= 1");
+            assertLe(sentryId, sentries.length, "Expected sentry ID <= N");
+            assertEq(sentries[sentryId - 1], sentry, "Expected array to have sentry at given index");
+            assertTrue(_contains(sentries[sentryId:], sentry), "Expected array to have duplicated address");
         } else {
             revert("Unexpected error");
         }
@@ -1040,6 +1101,85 @@ contract DaveAppFactoryTest is Test {
         }
     }
 
+    function _submitSentryClaim(
+        IApplication appContract,
+        IDaveConsensus daveConsensus,
+        uint256 epochNumber,
+        uint256 sentryId,
+        Machine.Hash postEpochMachineStateHash
+    ) internal {
+        address sentry = daveConsensus.getSentryById(sentryId);
+
+        // Pick a random hash for testing error cases
+        Machine.Hash randomHash = Machine.Hash.wrap(bytes32(vm.randomUint()));
+
+        // Attempt to claim a random hash for the wrong epoch number
+        uint256 randomEpochNumber = _randomUintNotEq(epochNumber);
+        vm.prank(sentry);
+        vm.expectRevert(_encodeIncorrectEpochNumber(randomEpochNumber, epochNumber));
+        daveConsensus.submitSentryClaim(randomEpochNumber, randomHash);
+
+        // Make a non-sentry attempt to claim a random hash
+        address nonSentry = _randomNonSentry(daveConsensus);
+        vm.prank(nonSentry);
+        vm.expectRevert(_encodeCallerIsNotSentry(nonSentry));
+        daveConsensus.submitSentryClaim(epochNumber, randomHash);
+
+        // Simulate foreclosure and attempt to claim a random hash
+        vm.expectRevert(_encodeApplicationForeclosed(address(appContract)));
+        this.simulateForeclosureAndSentryClaim(appContract, daveConsensus, epochNumber, sentry, randomHash);
+
+        // Ensure the sentry has not submitted a claim yet
+        assertFalse(daveConsensus.hasSentryClaimedInEpoch(epochNumber, sentryId));
+
+        // Get the current number of claims before the submission for later comparison
+        uint256 claimCountBefore = daveConsensus.getSentryClaimCount(epochNumber, postEpochMachineStateHash);
+        assertLe(claimCountBefore, daveConsensus.getNumberOfSentries());
+
+        // Make the sentry submit the claim while recording logs
+        vm.recordLogs();
+        vm.prank(sentry);
+        daveConsensus.submitSentryClaim(epochNumber, postEpochMachineStateHash);
+
+        // Check the logs for a SentryClaim event
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        uint256 numOfSentryClaimEvents;
+        for (uint256 i; i < logs.length; ++i) {
+            Vm.Log memory log = logs[i];
+            if (log.emitter == address(daveConsensus)) {
+                assertGe(log.topics.length, 1);
+                bytes32 topic0 = log.topics[0];
+                if (topic0 == IDaveConsensus.SentryClaim.selector) {
+                    assertEq(log.topics.length, 4);
+                    assertEq(log.topics[1], bytes32(epochNumber));
+                    assertEq(log.topics[2], bytes32(sentryId));
+                    assertEq(log.topics[3], bytes32(uint256(uint160(sentry))));
+                    assertEq(log.data, abi.encode(postEpochMachineStateHash));
+                    ++numOfSentryClaimEvents;
+                } else {
+                    revert UnexpectedLogTopic0(log);
+                }
+            } else {
+                revert UnexpectedLogEmitter(log);
+            }
+        }
+        assertEq(numOfSentryClaimEvents, 1);
+
+        // Ensure the sentry has claimed in epoch according to the contract and that
+        // the number of claims in the epoch increased by 1
+        assertTrue(daveConsensus.hasSentryClaimedInEpoch(epochNumber, sentryId));
+        assertEq(daveConsensus.getSentryClaimCount(epochNumber, postEpochMachineStateHash), claimCountBefore + 1);
+    }
+
+    function _attemptSentryClaimResubmission(IDaveConsensus daveConsensus, uint256 epochNumber, uint256 sentryId)
+        internal
+    {
+        address randomSentry = daveConsensus.getSentryById(sentryId);
+        vm.expectRevert(_encodeSentryAlreadyClaimed(epochNumber, sentryId));
+        vm.prank(randomSentry);
+        daveConsensus.submitSentryClaim(epochNumber, Machine.Hash.wrap(bytes32(vm.randomUint())));
+    }
+
     function _encodeApplicationMismatch(address expected, address obtained)
         internal
         pure
@@ -1084,5 +1224,84 @@ contract DaveAppFactoryTest is Test {
 
     function _encodeApplicationForeclosed(address appContract) internal pure returns (bytes memory encodedError) {
         return abi.encodeWithSelector(IApplicationChecker.ApplicationForeclosed.selector, appContract);
+    }
+
+    function _encodeSentryAlreadyClaimed(uint256 epochNumber, uint256 sentryId)
+        internal
+        pure
+        returns (bytes memory encodedError)
+    {
+        return abi.encodeWithSelector(IDaveConsensus.SentryAlreadyClaimed.selector, epochNumber, sentryId);
+    }
+
+    function _encodeCallerIsNotSentry(address caller) internal pure returns (bytes memory encodedError) {
+        return abi.encodeWithSelector(IDaveConsensus.CallerIsNotSentry.selector, caller);
+    }
+
+    function _randomUintNotEq(uint256 n) internal returns (uint256 m) {
+        while (true) {
+            m = vm.randomUint();
+            if (n != m) {
+                break;
+            }
+        }
+    }
+
+    function _contains(address[] memory array, address value) internal pure returns (bool) {
+        for (uint256 i; i < array.length; ++i) {
+            if (array[i] == value) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function _randomAddressNotIn(address[] memory disallowList) internal returns (address addr) {
+        while (true) {
+            addr = vm.randomAddress();
+            if (!_contains(disallowList, addr)) {
+                break;
+            }
+        }
+    }
+
+    function _randomNonSentry(IDaveConsensus daveConsensus) internal returns (address nonSentry) {
+        while (true) {
+            nonSentry = vm.randomAddress();
+            if (daveConsensus.getSentryId(nonSentry) == 0) {
+                break;
+            }
+        }
+    }
+
+    function _getSentries(IDaveConsensus daveConsensus) internal view returns (address[] memory sentries) {
+        sentries = new address[](daveConsensus.getNumberOfSentries());
+        for (uint256 i; i < sentries.length; ++i) {
+            uint256 sentryId = i + 1;
+            sentries[i] = daveConsensus.getSentryById(sentryId);
+            assertEq(daveConsensus.getSentryId(sentries[i]), sentryId);
+            assertNotEq(sentries[i], address(0));
+        }
+    }
+
+    function _getShuffledSentryIds(uint256 numOfSentries) internal returns (uint256[] memory sentryIds) {
+        sentryIds = new uint256[](numOfSentries);
+        for (uint256 i; i < numOfSentries; ++i) {
+            sentryIds[i] = i + 1;
+        }
+        _shuffleInPlace(sentryIds);
+    }
+
+    function _shuffleInPlace(uint256[] memory array) internal {
+        // Nothing to be done.
+        if (array.length == 0) {
+            return;
+        }
+
+        // Fisher-Yates shuffle
+        for (uint256 i = array.length - 1; i > 0; --i) {
+            uint256 j = vm.randomUint(0, i);
+            (array[i], array[j]) = (array[j], array[i]);
+        }
     }
 }

--- a/cartesi-rollups/contracts/test/DaveAppFactory.t.sol
+++ b/cartesi-rollups/contracts/test/DaveAppFactory.t.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.22;
+pragma solidity ^0.8.30;
 
 import {Test} from "forge-std-1.9.6/src/Test.sol";
 import {Vm} from "forge-std-1.9.6/src/Vm.sol";

--- a/cartesi-rollups/contracts/test/DaveAppFactory.t.sol
+++ b/cartesi-rollups/contracts/test/DaveAppFactory.t.sol
@@ -431,15 +431,15 @@ contract DaveAppFactoryTest is Test {
                 if (log.topics[0] == IDaveConsensus.EpochStaged.selector) {
                     ++numOfEpochStagedEvents;
 
-                    uint256 arg1;
+                    assertEq(log.topics[1], bytes32(0)); // epochNumber
+
+                    bytes32 arg1;
                     bytes32 arg2;
-                    bytes32 arg3;
 
-                    (arg1, arg2, arg3) = abi.decode(log.data, (uint256, bytes32, bytes32));
+                    (arg1, arg2) = abi.decode(log.data, (bytes32, bytes32));
 
-                    assertEq(arg1, 0); // epochNumber
-                    assertEq(arg2, machineMerkleRoot); // stagedPostEpochMachineStateHash
-                    assertEq(arg3, outputsMerkleRoot); // stagedPostEpochOutputsMerkleRoot
+                    assertEq(arg1, machineMerkleRoot); // stagedPostEpochMachineStateHash
+                    assertEq(arg2, outputsMerkleRoot); // stagedPostEpochOutputsMerkleRoot
                 } else {
                     revert UnexpectedLogTopic0(log);
                 }
@@ -676,22 +676,21 @@ contract DaveAppFactoryTest is Test {
                 if (log.topics[0] == IDaveConsensus.EpochSealed.selector) {
                     ++numOfEpochSealedEvents;
 
+                    assertEq(log.topics[1], bytes32(uint256(1))); // epochNumber
+
                     uint256 arg1;
                     uint256 arg2;
-                    uint256 arg3;
+                    bytes32 arg3;
                     bytes32 arg4;
-                    bytes32 arg5;
-                    address arg6;
+                    address arg5;
 
-                    (arg1, arg2, arg3, arg4, arg5, arg6) =
-                        abi.decode(log.data, (uint256, uint256, uint256, bytes32, bytes32, address));
+                    (arg1, arg2, arg3, arg4, arg5) = abi.decode(log.data, (uint256, uint256, bytes32, bytes32, address));
 
-                    assertEq(arg1, 1); // epochNumber
-                    assertEq(arg2, 0); // inputIndexLowerBound
-                    assertEq(arg3, inputs.length); // inputIndexUpperBound
-                    assertEq(arg4, machineMerkleRoot); // initialMachineStateHash
-                    assertEq(arg5, outputsMerkleRoot);
-                    assertEq(arg6, address(tournament));
+                    assertEq(arg1, 0); // inputIndexLowerBound
+                    assertEq(arg2, inputs.length); // inputIndexUpperBound
+                    assertEq(arg3, machineMerkleRoot); // initialMachineStateHash
+                    assertEq(arg4, outputsMerkleRoot);
+                    assertEq(arg5, address(tournament));
                 } else {
                     revert UnexpectedLogTopic0(log);
                 }
@@ -988,22 +987,21 @@ contract DaveAppFactoryTest is Test {
                 } else if (log.topics[0] == IDaveConsensus.EpochSealed.selector) {
                     ++numOfEpochSealedEvents;
 
+                    assertEq(log.topics[1], bytes32(0)); // epochNumber
+
                     uint256 arg1;
                     uint256 arg2;
-                    uint256 arg3;
+                    bytes32 arg3;
                     bytes32 arg4;
-                    bytes32 arg5;
-                    address arg6;
+                    address arg5;
 
-                    (arg1, arg2, arg3, arg4, arg5, arg6) =
-                        abi.decode(log.data, (uint256, uint256, uint256, bytes32, bytes32, address));
+                    (arg1, arg2, arg3, arg4, arg5) = abi.decode(log.data, (uint256, uint256, bytes32, bytes32, address));
 
-                    assertEq(arg1, 0); // epochNumber
-                    assertEq(arg2, 0); // inputIndexLowerBound
-                    assertEq(arg3, 0); // inputIndexUpperBound
-                    assertEq(arg4, templateHash); // initialMachineStateHash
-                    assertEq(arg5, bytes32(0)); // outputsMerkleRoot
-                    assertEq(arg6, address(tournament)); // tournament
+                    assertEq(arg1, 0); // inputIndexLowerBound
+                    assertEq(arg2, 0); // inputIndexUpperBound
+                    assertEq(arg3, templateHash); // initialMachineStateHash
+                    assertEq(arg4, bytes32(0)); // outputsMerkleRoot
+                    assertEq(arg5, address(tournament)); // tournament
                 } else {
                     revert UnexpectedLogTopic0(log);
                 }

--- a/cartesi-rollups/contracts/test/DaveAppFactory.t.sol
+++ b/cartesi-rollups/contracts/test/DaveAppFactory.t.sol
@@ -86,15 +86,20 @@ contract DaveAppFactoryTest is Test {
         _daveAppFactory = new DaveAppFactory(_inputBox, _appFactory, _tournamentFactory);
     }
 
-    function testNewDaveApp(bytes32 templateHash, WithdrawalConfig calldata withdrawalConfig, bytes32 salt) external {
-        _randomizeBlockNumber();
+    function testNewDaveApp(
+        bytes32 templateHash,
+        uint64 claimStagingPeriod,
+        WithdrawalConfig calldata withdrawalConfig,
+        bytes32 salt
+    ) external {
+        _randomizeBlockNumber(claimStagingPeriod);
 
         (address precalculatedAppContractAddress, address precalculatedDaveConsensusAddress) =
-            _daveAppFactory.calculateDaveAppAddress(templateHash, withdrawalConfig, salt);
+            _daveAppFactory.calculateDaveAppAddress(templateHash, claimStagingPeriod, withdrawalConfig, salt);
 
         vm.recordLogs();
 
-        try _daveAppFactory.newDaveApp(templateHash, withdrawalConfig, salt) returns (
+        try _daveAppFactory.newDaveApp(templateHash, claimStagingPeriod, withdrawalConfig, salt) returns (
             IApplication appContract, IDaveConsensus daveConsensus
         ) {
             Vm.Log[] memory logs = vm.getRecordedLogs();
@@ -111,10 +116,10 @@ contract DaveAppFactoryTest is Test {
                 "calculateDaveAppAddress(...)[1] != newDaveApp(...)[1]"
             );
 
-            _testNewDaveAppSuccess(templateHash, withdrawalConfig, appContract, daveConsensus, logs);
+            _testNewDaveAppSuccess(templateHash, claimStagingPeriod, withdrawalConfig, appContract, daveConsensus, logs);
 
             (precalculatedAppContractAddress, precalculatedDaveConsensusAddress) =
-                _daveAppFactory.calculateDaveAppAddress(templateHash, withdrawalConfig, salt);
+                _daveAppFactory.calculateDaveAppAddress(templateHash, claimStagingPeriod, withdrawalConfig, salt);
 
             assertEq(
                 precalculatedAppContractAddress,
@@ -133,7 +138,7 @@ contract DaveAppFactoryTest is Test {
         }
 
         // Cannot deploy an application with the same salt twice
-        try _daveAppFactory.newDaveApp(templateHash, withdrawalConfig, salt) {
+        try _daveAppFactory.newDaveApp(templateHash, claimStagingPeriod, withdrawalConfig, salt) {
             revert("second deterministic deployment did not revert");
         } catch (bytes memory errorData) {
             assertEq(
@@ -142,21 +147,22 @@ contract DaveAppFactoryTest is Test {
         }
     }
 
-    function testSettle(
+    function testStageAndAcceptTournamentResult(
         bytes32 templateHash,
+        uint64 claimStagingPeriod,
         WithdrawalConfig calldata withdrawalConfig,
         bytes32 salt,
         bytes32 outputsMerkleRoot,
-        bytes[] calldata inputPayloads,
-        bool foreclose
+        bytes[] calldata inputPayloads
     ) external {
-        _randomizeBlockNumber();
+        _randomizeBlockNumber(claimStagingPeriod);
 
         IApplication appContract;
         IDaveConsensus daveConsensus;
 
         vm.assumeNoRevert();
-        (appContract, daveConsensus) = _daveAppFactory.newDaveApp(templateHash, withdrawalConfig, salt);
+        (appContract, daveConsensus) =
+            _daveAppFactory.newDaveApp(templateHash, claimStagingPeriod, withdrawalConfig, salt);
 
         bytes[] memory inputs = new bytes[](inputPayloads.length);
 
@@ -164,7 +170,7 @@ contract DaveAppFactoryTest is Test {
             inputs[i] = _addInput(address(appContract), inputPayloads[i]);
         }
 
-        (,,, ITournament tournament) = daveConsensus.getCurrentSealedEpoch();
+        (,,, ITournament tournament,,,,) = daveConsensus.getCurrentSealedEpoch();
 
         bytes32[] memory outputsMerkleRootProof = _randomProof(Memory.LOG2_MAX_SIZE);
         bytes32 machineMerkleRoot = outputsMerkleRootProof.merkleRootAfterReplacement(
@@ -250,34 +256,47 @@ contract DaveAppFactoryTest is Test {
             uint256 val2;
             uint256 val3;
             ITournament val4;
+            bool val5;
 
-            (val1, val2, val3, val4) = daveConsensus.getCurrentSealedEpoch();
+            (val1, val2, val3, val4, val5,,,) = daveConsensus.getCurrentSealedEpoch();
 
             assertEq(val1, 0); // epochNumber
             assertEq(val2, 0); // inputIndexLowerBound
             assertEq(val3, 0); // inputIndexUpperBound
             assertEq(address(val4), address(tournament));
+            assertFalse(val5); // isTournamentResultStaged
         }
 
-        // Check epoch settlement readiness
+        // Check epoch staging readiness
+        {
+            bool val1;
+            bool val2;
+            uint256 val3;
+
+            (val1, val2, val3,,) = daveConsensus.canStageTournamentResult();
+
+            assertFalse(val1); // isFinished
+            assertFalse(val2); // isTournamentResultStaged
+            assertEq(val3, 0); // epochNumber
+        }
+
+        // Check epoch acceptance readiness
         {
             bool val1;
             uint256 val2;
 
-            (val1, val2,) = daveConsensus.canSettle();
+            (val1,, val2,,) = daveConsensus.canAcceptStagedTournamentResult();
 
-            assertFalse(val1); // isFinished
+            assertFalse(val1); // isTournamentResultStaged
             assertEq(val2, 0); // epochNumber
         }
 
-        address settler = vm.randomAddress();
-
-        vm.startPrank(settler);
         vm.expectRevert(IDaveConsensus.TournamentNotFinishedYet.selector);
-        daveConsensus.settle(0, outputsMerkleRoot, outputsMerkleRootProof);
-        vm.stopPrank();
+        vm.prank(vm.randomAddress());
+        daveConsensus.stageTournamentResult(0, outputsMerkleRoot, outputsMerkleRootProof);
 
-        vm.roll(vm.randomUint(vm.getBlockNumber() + Time.Duration.unwrap(MAX_ALLOWANCE), type(uint64).max));
+        uint64 maxBlockNumber = type(uint64).max - claimStagingPeriod;
+        vm.roll(vm.randomUint(vm.getBlockNumber() + Time.Duration.unwrap(MAX_ALLOWANCE), maxBlockNumber));
 
         assertTrue(tournament.isClosed());
         assertTrue(tournament.isFinished());
@@ -300,72 +319,306 @@ contract DaveAppFactoryTest is Test {
             uint256 val2;
             uint256 val3;
             ITournament val4;
+            bool val5;
 
-            (val1, val2, val3, val4) = daveConsensus.getCurrentSealedEpoch();
+            (val1, val2, val3, val4, val5,,,) = daveConsensus.getCurrentSealedEpoch();
 
             assertEq(val1, 0); // epochNumber
             assertEq(val2, 0); // inputIndexLowerBound
             assertEq(val3, 0); // inputIndexUpperBound
             assertEq(address(val4), address(tournament));
+            assertFalse(val5); // isTournamentResultStaged
         }
 
-        // Check epoch settlement readiness
+        // Check epoch staging readiness
+        {
+            bool val1;
+            bool val2;
+            uint256 val3;
+            Tree.Node val4;
+            Machine.Hash val5;
+
+            (val1, val2, val3, val4, val5) = daveConsensus.canStageTournamentResult();
+
+            assertTrue(val1); //  isFinished
+            assertFalse(val2); // isTournamentResultStaged
+            assertEq(val3, 0); // epochNumber
+            assertEq(Tree.Node.unwrap(val4), commitment);
+            assertEq(Machine.Hash.unwrap(val5), machineMerkleRoot);
+        }
+
+        // Check epoch acceptance readiness
         {
             bool val1;
             uint256 val2;
-            Tree.Node val3;
 
-            (val1, val2, val3) = daveConsensus.canSettle();
+            (val1,, val2,,) = daveConsensus.canAcceptStagedTournamentResult();
 
-            assertTrue(val1); //  isFinished
+            assertFalse(val1); // isTournamentResultStaged
             assertEq(val2, 0); // epochNumber
-            assertEq(Tree.Node.unwrap(val3), commitment);
         }
 
-        vm.startPrank(settler);
+        // Try staging tournament result with an invalid epoch number
         {
             uint256 incorrectEpochNumber = vm.randomUint(1, type(uint256).max);
             vm.expectRevert(_encodeIncorrectEpochNumber(incorrectEpochNumber, 0));
-            daveConsensus.settle(incorrectEpochNumber, outputsMerkleRoot, outputsMerkleRootProof);
+            vm.prank(vm.randomAddress());
+            daveConsensus.stageTournamentResult(incorrectEpochNumber, outputsMerkleRoot, outputsMerkleRootProof);
         }
-        vm.stopPrank();
 
-        if (foreclose) {
-            vm.startPrank(appContract.getGuardian());
-            appContract.foreclose();
-            vm.stopPrank();
+        // Try staging tournament result with invalid outputs Merkle root proof size
+        while (true) {
+            uint256 invalidProofSize = vm.randomUint(0, 2 * outputsMerkleRootProof.length + 1);
+            if (invalidProofSize != outputsMerkleRootProof.length) {
+                bytes32[] memory invalidOutputsMerkleRootProof = _randomProof(invalidProofSize);
+                vm.expectRevert(_encodeInvalidOutputsMerkleRootProofSize(invalidProofSize));
+                vm.prank(vm.randomAddress());
+                daveConsensus.stageTournamentResult(0, outputsMerkleRoot, invalidOutputsMerkleRootProof);
+                break;
+            }
         }
+
+        // Try staging tournament result with invalid outputs Merkle root
+        while (true) {
+            bytes32 invalidOutputsMerkleRoot = bytes32(vm.randomUint());
+            if (invalidOutputsMerkleRoot != outputsMerkleRoot) {
+                vm.expectRevert(_encodeInvalidOutputsMerkleRootProof(machineMerkleRoot));
+                vm.prank(vm.randomAddress());
+                daveConsensus.stageTournamentResult(0, invalidOutputsMerkleRoot, outputsMerkleRootProof);
+                break;
+            }
+        }
+
+        vm.expectRevert(_encodeApplicationForeclosed(address(appContract)));
+        this.simulateForeclosureAndStaging(appContract, daveConsensus, 0, outputsMerkleRoot, outputsMerkleRootProof);
+
+        uint256 stagingBlockNumber = vm.getBlockNumber();
 
         vm.recordLogs();
 
-        vm.startPrank(settler);
-        try daveConsensus.settle(0, outputsMerkleRoot, outputsMerkleRootProof) {
-            assertFalse(foreclose);
-        } catch (bytes memory errorData) {
-            (bool isValidError, bytes32 errorSelector,) = errorData.consumeBytes4();
-            assertTrue(isValidError, "Expected error to contain a 4-byte selector");
-            if (errorSelector == IApplicationChecker.ApplicationForeclosed.selector) {
-                assertTrue(foreclose, "Application was foreclosed prior to settlement attempt");
-                assertTrue(appContract.isForeclosed(), "Application is indeed foreclosed");
-                return; // do not continue test case
-            } else {
-                revert("Unexpected error");
-            }
-        }
-        vm.stopPrank();
+        vm.prank(vm.randomAddress());
+        daveConsensus.stageTournamentResult(0, outputsMerkleRoot, outputsMerkleRootProof);
 
         logs = vm.getRecordedLogs();
 
+        uint256 numOfEpochStagedEvents;
+
+        for (uint256 i; i < logs.length; ++i) {
+            Vm.Log memory log = logs[i];
+            if (log.emitter == address(daveConsensus)) {
+                if (log.topics[0] == IDaveConsensus.EpochStaged.selector) {
+                    ++numOfEpochStagedEvents;
+
+                    uint256 arg1;
+                    bytes32 arg2;
+                    bytes32 arg3;
+
+                    (arg1, arg2, arg3) = abi.decode(log.data, (uint256, bytes32, bytes32));
+
+                    assertEq(arg1, 0); // epochNumber
+                    assertEq(arg2, machineMerkleRoot); // stagedPostEpochMachineStateHash
+                    assertEq(arg3, outputsMerkleRoot); // stagedPostEpochOutputsMerkleRoot
+                } else {
+                    revert UnexpectedLogTopic0(log);
+                }
+            } else {
+                revert UnexpectedLogEmitter(log);
+            }
+        }
+
+        assertEq(numOfEpochStagedEvents, 1);
+
+        // Check current sealed epoch
         {
             uint256 val1;
             uint256 val2;
             uint256 val3;
+            ITournament val4;
+            bool val5;
+            uint256 val6;
+            Machine.Hash val7;
+            bytes32 val8;
 
-            (val1, val2, val3, tournament) = daveConsensus.getCurrentSealedEpoch();
+            (val1, val2, val3, val4, val5, val6, val7, val8) = daveConsensus.getCurrentSealedEpoch();
+
+            assertEq(val1, 0); // epochNumber
+            assertEq(val2, 0); // inputIndexLowerBound
+            assertEq(val3, 0); // inputIndexUpperBound
+            assertEq(address(val4), address(tournament));
+            assertTrue(val5); // isTournamentResultStaged
+            assertEq(val6, stagingBlockNumber);
+            assertEq(Machine.Hash.unwrap(val7), machineMerkleRoot);
+            assertEq(val8, outputsMerkleRoot);
+        }
+
+        // Check epoch staging readiness
+        {
+            bool val1;
+            bool val2;
+            uint256 val3;
+            Tree.Node val4;
+            Machine.Hash val5;
+
+            (val1, val2, val3, val4, val5) = daveConsensus.canStageTournamentResult();
+
+            assertTrue(val1); //  isFinished
+            assertTrue(val2); // isTournamentResultStaged
+            assertEq(val3, 0); // epochNumber
+            assertEq(Tree.Node.unwrap(val4), commitment);
+            assertEq(Machine.Hash.unwrap(val5), machineMerkleRoot);
+        }
+
+        // Check epoch acceptance readiness
+        {
+            bool val1;
+            bool val2;
+            uint256 val3;
+            Machine.Hash val4;
+            bytes32 val5;
+
+            (val1, val2, val3, val4, val5) = daveConsensus.canAcceptStagedTournamentResult();
+
+            assertTrue(val1); // isTournamentResultStaged
+            assertEq(val2, claimStagingPeriod == 0); // isClaimStagingPeriodOver
+            assertEq(val3, 0); // epochNumber
+            assertEq(Machine.Hash.unwrap(val4), machineMerkleRoot);
+            assertEq(val5, outputsMerkleRoot);
+        }
+
+        assertEq(daveConsensus.getLastFinalizedMachineMerkleRoot(address(appContract)), bytes32(0));
+        assertFalse(daveConsensus.isOutputsMerkleRootValid(address(appContract), outputsMerkleRoot));
+
+        // Try re-staging tournament result
+        vm.expectRevert(IDaveConsensus.TournamentResultAlreadyStaged.selector);
+        vm.prank(vm.randomAddress());
+        daveConsensus.stageTournamentResult(0, outputsMerkleRoot, outputsMerkleRootProof);
+
+        // Try accepting tournament result before claim staging period is over
+        if (claimStagingPeriod >= 1) {
+            uint256 numberOfBlocksAfterStaging = vm.randomUint(0, claimStagingPeriod - 1);
+            vm.roll(stagingBlockNumber + numberOfBlocksAfterStaging);
+            vm.expectRevert(_encodeClaimStagingPeriodNotOverYet(numberOfBlocksAfterStaging, claimStagingPeriod));
+            vm.prank(vm.randomAddress());
+            daveConsensus.acceptStagedTournamentResult(0);
+        }
+
+        vm.roll(vm.randomUint(stagingBlockNumber + claimStagingPeriod, type(uint64).max));
+
+        // Check current sealed epoch
+        {
+            uint256 val1;
+            uint256 val2;
+            uint256 val3;
+            ITournament val4;
+            bool val5;
+            uint256 val6;
+            Machine.Hash val7;
+            bytes32 val8;
+
+            (val1, val2, val3, val4, val5, val6, val7, val8) = daveConsensus.getCurrentSealedEpoch();
+
+            assertEq(val1, 0); // epochNumber
+            assertEq(val2, 0); // inputIndexLowerBound
+            assertEq(val3, 0); // inputIndexUpperBound
+            assertEq(address(val4), address(tournament));
+            assertTrue(val5); // isTournamentResultStaged
+            assertEq(val6, stagingBlockNumber);
+            assertEq(Machine.Hash.unwrap(val7), machineMerkleRoot);
+            assertEq(val8, outputsMerkleRoot);
+        }
+
+        // Check epoch staging readiness
+        {
+            bool val1;
+            bool val2;
+            uint256 val3;
+            Tree.Node val4;
+            Machine.Hash val5;
+
+            (val1, val2, val3, val4, val5) = daveConsensus.canStageTournamentResult();
+
+            assertTrue(val1); //  isFinished
+            assertTrue(val2); // isTournamentResultStaged
+            assertEq(val3, 0); // epochNumber
+            assertEq(Tree.Node.unwrap(val4), commitment);
+            assertEq(Machine.Hash.unwrap(val5), machineMerkleRoot);
+        }
+
+        // Check epoch acceptance readiness
+        {
+            bool val1;
+            bool val2;
+            uint256 val3;
+            Machine.Hash val4;
+            bytes32 val5;
+
+            (val1, val2, val3, val4, val5) = daveConsensus.canAcceptStagedTournamentResult();
+
+            assertTrue(val1); // isTournamentResultStaged
+            assertTrue(val2); // isClaimStagingPeriodOver
+            assertEq(val3, 0); // epochNumber
+            assertEq(Machine.Hash.unwrap(val4), machineMerkleRoot);
+            assertEq(val5, outputsMerkleRoot);
+        }
+
+        assertEq(daveConsensus.getLastFinalizedMachineMerkleRoot(address(appContract)), bytes32(0));
+        assertFalse(daveConsensus.isOutputsMerkleRootValid(address(appContract), outputsMerkleRoot));
+
+        vm.expectRevert(_encodeApplicationForeclosed(address(appContract)));
+        this.simulateForeclosureAndAcceptance(appContract, daveConsensus, 0);
+
+        vm.recordLogs();
+
+        vm.prank(vm.randomAddress());
+        daveConsensus.acceptStagedTournamentResult(0);
+
+        logs = vm.getRecordedLogs();
+
+        // Check current sealed epoch
+        {
+            uint256 val1;
+            uint256 val2;
+            uint256 val3;
+            ITournament val4;
+            bool val5;
+
+            (val1, val2, val3, val4, val5,,,) = daveConsensus.getCurrentSealedEpoch();
 
             assertEq(val1, 1); // epochNumber
             assertEq(val2, 0); // inputIndexLowerBound
             assertEq(val3, inputs.length); // inputIndexUpperBound
+            tournament = val4;
+            assertFalse(val5); // isTournamentResultStaged
+        }
+
+        // Arbitration result
+        {
+            (bool isFinished,,) = tournament.arbitrationResult();
+            assertFalse(isFinished);
+        }
+
+        // Check epoch staging readiness
+        {
+            bool val1;
+            bool val2;
+            uint256 val3;
+
+            (val1, val2, val3,,) = daveConsensus.canStageTournamentResult();
+
+            assertFalse(val1); // isFinished
+            assertFalse(val2); // isTournamentResultStaged
+            assertEq(val3, 1); // epochNumber
+        }
+
+        // Check epoch acceptance readiness
+        {
+            bool val1;
+            uint256 val2;
+
+            (val1,, val2,,) = daveConsensus.canAcceptStagedTournamentResult();
+
+            assertFalse(val1); // isTournamentResultStaged
+            assertEq(val2, 1); // epochNumber
         }
 
         uint256 numOfTournamentCreatedEvents;
@@ -402,6 +655,8 @@ contract DaveAppFactoryTest is Test {
                     assertEq(arg4, machineMerkleRoot); // initialMachineStateHash
                     assertEq(arg5, outputsMerkleRoot);
                     assertEq(arg6, address(tournament));
+                } else {
+                    revert UnexpectedLogTopic0(log);
                 }
             } else {
                 revert UnexpectedLogEmitter(log);
@@ -420,15 +675,48 @@ contract DaveAppFactoryTest is Test {
         }
 
         {
-            uint256 inputIndexWithinBounds = vm.randomUint(inputs.length, type(uint256).max);
+            uint256 inputIndexOutOfBounds = vm.randomUint(inputs.length, type(uint256).max);
             uint256 inputLength = vm.randomUint(0, 100);
             bytes memory input = vm.randomBytes(inputLength);
-            assertEq(daveConsensus.provideMerkleRootOfInput(inputIndexWithinBounds, input), bytes32(0));
+            assertEq(daveConsensus.provideMerkleRootOfInput(inputIndexOutOfBounds, input), bytes32(0));
         }
+    }
+
+    /// @notice This function is used to simulate a foreclosure and a tournament-result staging.
+    /// If the staging succeeds, then the function reverts with error message "Successful staging".
+    /// If the staging fails, then the function propagates the error from the DaveConsensus contract.
+    function simulateForeclosureAndStaging(
+        IApplication appContract,
+        IDaveConsensus daveConsensus,
+        uint256 epochNumber,
+        bytes32 outputsMerkleRoot,
+        bytes32[] calldata proof
+    ) external {
+        vm.prank(appContract.getGuardian());
+        appContract.foreclose();
+        vm.prank(vm.randomAddress());
+        daveConsensus.stageTournamentResult(epochNumber, outputsMerkleRoot, proof);
+        revert("Successful staging");
+    }
+
+    /// @notice This function is used to simulate a foreclosure and a tournament-result acceptance.
+    /// If the acceptance succeeds, then the function reverts with error message "Successful acceptance".
+    /// If the acceptance fails, then the function propagates the error from the DaveConsensus contract.
+    function simulateForeclosureAndAcceptance(
+        IApplication appContract,
+        IDaveConsensus daveConsensus,
+        uint256 epochNumber
+    ) external {
+        vm.prank(appContract.getGuardian());
+        appContract.foreclose();
+        vm.prank(vm.randomAddress());
+        daveConsensus.acceptStagedTournamentResult(epochNumber);
+        revert("Successful acceptance");
     }
 
     function _testNewDaveAppSuccess(
         bytes32 templateHash,
+        uint64 claimStagingPeriod,
         WithdrawalConfig calldata withdrawalConfig,
         IApplication appContract,
         IDaveConsensus daveConsensus,
@@ -449,12 +737,19 @@ contract DaveAppFactoryTest is Test {
             uint256 val1;
             uint256 val2;
             uint256 val3;
+            ITournament val4;
+            bool val5;
+            uint256 val6;
+            Machine.Hash val7;
+            bytes32 val8;
 
-            (val1, val2, val3, tournament) = daveConsensus.getCurrentSealedEpoch();
+            (val1, val2, val3, val4, val5, val6, val7, val8) = daveConsensus.getCurrentSealedEpoch();
 
             assertEq(val1, 0); // epochNumber
             assertEq(val2, 0); // inputIndexLowerBound
             assertEq(val3, 0); // inputIndexUpperBound
+            tournament = val4;
+            assertFalse(val5); // isTournamentResultStaged
         }
 
         for (uint256 i; i < logs.length; ++i) {
@@ -612,17 +907,20 @@ contract DaveAppFactoryTest is Test {
         // Check epoch settlement readiness
         {
             bool val1;
-            uint256 val2;
+            bool val2;
+            uint256 val3;
 
-            (val1, val2,) = daveConsensus.canSettle();
+            (val1, val2, val3,,) = daveConsensus.canStageTournamentResult();
 
             assertFalse(val1); // isFinished
-            assertEq(val2, 0); // epochNumber
+            assertFalse(val2); // isTournamentResultStaged
+            assertEq(val3, 0); // epochNumber
         }
 
         assertEq(address(daveConsensus.getInputBox()), address(_inputBox));
         assertEq(address(daveConsensus.getApplicationContract()), address(appContract));
         assertEq(address(daveConsensus.getTournamentFactory()), address(_tournamentFactory));
+        assertEq(daveConsensus.getClaimStagingPeriod(), claimStagingPeriod);
         assertEq(daveConsensus.getDeploymentBlockNumber(), vm.getBlockNumber());
         assertTrue(daveConsensus.supportsInterface(type(IERC165).interfaceId));
         assertTrue(daveConsensus.supportsInterface(type(IOutputsMerkleRootValidator).interfaceId));
@@ -680,12 +978,20 @@ contract DaveAppFactoryTest is Test {
         }
     }
 
-    function _randomizeBlockNumber() internal {
+    function _randomizeBlockNumber(uint64 claimStagingPeriod) internal {
         // We limit the block number by type(uint64).max because the PRT contracts
         // use block numbers for time-keeping, and stores them as uint64 values.
-        // We also give some slack (the maximum tournament allowance) so we can
-        // fast-forward to a block in which the tournament is closed.
-        vm.roll(vm.randomUint(vm.getBlockNumber(), type(uint64).max - Time.Duration.unwrap(MAX_ALLOWANCE)));
+        // We assume there is some slack so we can fast-forward to a block in which
+        // the tournament is closed, and we can stage the tournament result, and a
+        // block in which the staged tournament result can be accepted.
+        // We type the claim staging period as uint64 because otherwise the fuzzer
+        // would often pick values too high for these assumptions.
+        uint256 blockNumber = vm.getBlockNumber();
+        uint64 maxAllowance = Time.Duration.unwrap(MAX_ALLOWANCE);
+        vm.assume(blockNumber <= type(uint256).max - maxAllowance);
+        vm.assume(blockNumber + maxAllowance <= type(uint256).max - claimStagingPeriod);
+        vm.assume(blockNumber + maxAllowance + claimStagingPeriod <= type(uint64).max);
+        vm.roll(blockNumber + vm.randomUint(0, type(uint64).max - maxAllowance - claimStagingPeriod));
     }
 
     function _randomProof(uint256 n) internal returns (bytes32[] memory proof) {
@@ -748,5 +1054,35 @@ contract DaveAppFactoryTest is Test {
         returns (bytes memory encodedError)
     {
         return abi.encodeWithSelector(IDaveConsensus.IncorrectEpochNumber.selector, received, actual);
+    }
+
+    function _encodeInvalidOutputsMerkleRootProofSize(uint256 suppliedProofSize)
+        internal
+        pure
+        returns (bytes memory encodedError)
+    {
+        return abi.encodeWithSelector(IDaveConsensus.InvalidOutputsMerkleRootProofSize.selector, suppliedProofSize);
+    }
+
+    function _encodeInvalidOutputsMerkleRootProof(bytes32 machineMerkleRoot)
+        internal
+        pure
+        returns (bytes memory encodedError)
+    {
+        return abi.encodeWithSelector(IDaveConsensus.InvalidOutputsMerkleRootProof.selector, machineMerkleRoot);
+    }
+
+    function _encodeClaimStagingPeriodNotOverYet(uint256 numberOfBlocksAfterStaging, uint256 claimStagingPeriod)
+        internal
+        pure
+        returns (bytes memory encodedError)
+    {
+        return abi.encodeWithSelector(
+            IDaveConsensus.ClaimStagingPeriodNotOverYet.selector, numberOfBlocksAfterStaging, claimStagingPeriod
+        );
+    }
+
+    function _encodeApplicationForeclosed(address appContract) internal pure returns (bytes memory encodedError) {
+        return abi.encodeWithSelector(IApplicationChecker.ApplicationForeclosed.selector, appContract);
     }
 }

--- a/cartesi-rollups/contracts/test/DaveAppFactory.t.sol
+++ b/cartesi-rollups/contracts/test/DaveAppFactory.t.sol
@@ -90,18 +90,22 @@ contract DaveAppFactoryTest is Test {
     function testNewDaveApp(
         bytes32 templateHash,
         uint64 claimStagingPeriod,
+        address sentryManager,
         address[] calldata sentries,
         WithdrawalConfig calldata withdrawalConfig,
         bytes32 salt
     ) external {
         _randomizeBlockNumber(claimStagingPeriod);
 
-        (address precalculatedAppContractAddress, address precalculatedDaveConsensusAddress) =
-            _daveAppFactory.calculateDaveAppAddress(templateHash, claimStagingPeriod, sentries, withdrawalConfig, salt);
+        (address precalculatedAppContractAddress, address precalculatedDaveConsensusAddress) = _daveAppFactory.calculateDaveAppAddress(
+            templateHash, claimStagingPeriod, sentryManager, sentries, withdrawalConfig, salt
+        );
 
         vm.recordLogs();
 
-        try _daveAppFactory.newDaveApp(templateHash, claimStagingPeriod, sentries, withdrawalConfig, salt) returns (
+        try _daveAppFactory.newDaveApp(
+            templateHash, claimStagingPeriod, sentryManager, sentries, withdrawalConfig, salt
+        ) returns (
             IApplication appContract, IDaveConsensus daveConsensus
         ) {
             Vm.Log[] memory logs = vm.getRecordedLogs();
@@ -119,12 +123,19 @@ contract DaveAppFactoryTest is Test {
             );
 
             _testNewDaveAppSuccess(
-                templateHash, claimStagingPeriod, sentries, withdrawalConfig, appContract, daveConsensus, logs
+                templateHash,
+                claimStagingPeriod,
+                sentryManager,
+                sentries,
+                withdrawalConfig,
+                appContract,
+                daveConsensus,
+                logs
             );
 
             (precalculatedAppContractAddress, precalculatedDaveConsensusAddress) =
                 _daveAppFactory.calculateDaveAppAddress(
-                    templateHash, claimStagingPeriod, sentries, withdrawalConfig, salt
+                    templateHash, claimStagingPeriod, sentryManager, sentries, withdrawalConfig, salt
                 );
 
             assertEq(
@@ -144,7 +155,9 @@ contract DaveAppFactoryTest is Test {
         }
 
         // Cannot deploy an application with the same salt twice
-        try _daveAppFactory.newDaveApp(templateHash, claimStagingPeriod, sentries, withdrawalConfig, salt) {
+        try _daveAppFactory.newDaveApp(
+            templateHash, claimStagingPeriod, sentryManager, sentries, withdrawalConfig, salt
+        ) {
             revert("second deterministic deployment did not revert");
         } catch (bytes memory errorData) {
             assertEq(
@@ -156,6 +169,7 @@ contract DaveAppFactoryTest is Test {
     function testStageAndAcceptTournamentResult(
         bytes32 templateHash,
         uint64 claimStagingPeriod,
+        address sentryManager,
         address[] calldata sentries,
         WithdrawalConfig calldata withdrawalConfig,
         bytes32 salt,
@@ -168,8 +182,9 @@ contract DaveAppFactoryTest is Test {
         IDaveConsensus daveConsensus;
 
         vm.assumeNoRevert();
-        (appContract, daveConsensus) =
-            _daveAppFactory.newDaveApp(templateHash, claimStagingPeriod, sentries, withdrawalConfig, salt);
+        (appContract, daveConsensus) = _daveAppFactory.newDaveApp(
+            templateHash, claimStagingPeriod, sentryManager, sentries, withdrawalConfig, salt
+        );
 
         bytes[] memory inputs = new bytes[](inputPayloads.length);
 
@@ -704,6 +719,110 @@ contract DaveAppFactoryTest is Test {
         }
     }
 
+    function testRotateSentry(
+        bytes32 templateHash,
+        uint64 claimStagingPeriod,
+        address sentryManager,
+        address[] calldata sentries,
+        WithdrawalConfig calldata withdrawalConfig,
+        bytes32 salt
+    ) external {
+        IApplication appContract;
+        IDaveConsensus daveConsensus;
+
+        vm.assumeNoRevert();
+        (appContract, daveConsensus) = _daveAppFactory.newDaveApp(
+            templateHash, claimStagingPeriod, sentryManager, sentries, withdrawalConfig, salt
+        );
+
+        uint256 numOfSentries = daveConsensus.getNumberOfSentries();
+        uint256 numOfRounds = 16;
+
+        for (uint256 round; round < numOfRounds; ++round) {
+            address nonSentryManager = _randomAddressNotEq(sentryManager);
+
+            vm.prank(nonSentryManager);
+            vm.expectRevert(_encodeCallerIsNotSentryManager(nonSentryManager));
+            daveConsensus.rotateSentry(vm.randomAddress(), vm.randomAddress());
+
+            vm.expectRevert(_encodeApplicationForeclosed(address(appContract)));
+            this.simulateForeclosureAndRotation(appContract, daveConsensus, vm.randomAddress(), vm.randomAddress());
+
+            address nonSentry = _randomNonSentry(daveConsensus);
+
+            vm.prank(sentryManager);
+            vm.expectRevert(_encodeCannotRotateNonSentry(nonSentry));
+            daveConsensus.rotateSentry(nonSentry, vm.randomAddress());
+
+            if (numOfSentries >= 1) {
+                uint256 sentryId = vm.randomUint(1, numOfSentries);
+                address sentry = daveConsensus.getSentryById(sentryId);
+                assertEq(daveConsensus.getSentryId(sentry), sentryId);
+
+                uint256 anotherSentryId = vm.randomUint(1, numOfSentries);
+                address anotherSentry = daveConsensus.getSentryById(anotherSentryId);
+                assertEq(daveConsensus.getSentryId(anotherSentry), anotherSentryId);
+
+                vm.prank(sentryManager);
+                vm.expectRevert(_encodeDuplicatedSentryAddress(anotherSentryId, anotherSentry));
+                daveConsensus.rotateSentry(sentry, anotherSentry);
+
+                vm.prank(sentryManager);
+                vm.expectRevert(ISentryErrors.ZeroSentryAddress.selector);
+                daveConsensus.rotateSentry(sentry, address(0));
+
+                address[] memory sentriesBefore = _getSentries(daveConsensus);
+                assertEq(sentriesBefore.length, numOfSentries);
+
+                address newSentry = _randomValidNonSentry(daveConsensus);
+
+                vm.recordLogs();
+
+                vm.prank(sentryManager);
+                daveConsensus.rotateSentry(sentry, newSentry);
+
+                Vm.Log[] memory logs = vm.getRecordedLogs();
+                uint256 numOfSentryRotationEvents;
+                for (uint256 i; i < logs.length; ++i) {
+                    Vm.Log memory log = logs[i];
+                    if (log.emitter == address(daveConsensus)) {
+                        assertGe(log.topics.length, 1);
+                        bytes32 topic0 = log.topics[0];
+                        if (topic0 == IDaveConsensus.SentryRotation.selector) {
+                            assertEq(log.topics.length, 4);
+                            assertEq(log.topics[1], bytes32(sentryId));
+                            assertEq(log.topics[2], bytes32(uint256(uint160(sentry))));
+                            assertEq(log.topics[3], bytes32(uint256(uint160(newSentry))));
+                            assertEq(log.data, abi.encode());
+                            ++numOfSentryRotationEvents;
+                        } else {
+                            revert UnexpectedLogTopic0(log);
+                        }
+                    } else {
+                        revert UnexpectedLogEmitter(log);
+                    }
+                }
+                assertEq(numOfSentryRotationEvents, 1);
+
+                assertEq(daveConsensus.getSentryId(sentry), 0);
+                assertEq(daveConsensus.getSentryId(newSentry), sentryId);
+                assertEq(daveConsensus.getSentryById(sentryId), newSentry);
+
+                address[] memory sentriesAfter = _getSentries(daveConsensus);
+                assertEq(sentriesBefore.length, sentriesAfter.length);
+
+                for (uint256 i; i < sentriesAfter.length; ++i) {
+                    if (sentryId == (i + 1)) {
+                        assertEq(sentriesBefore[i], sentry);
+                        assertEq(sentriesAfter[i], newSentry);
+                    } else {
+                        assertEq(sentriesBefore[i], sentriesAfter[i]);
+                    }
+                }
+            }
+        }
+    }
+
     /// @notice This function is used to simulate a foreclosure and a tournament-result staging.
     /// If the staging succeeds, then the function reverts with error message "Successful staging".
     /// If the staging fails, then the function propagates the error from the DaveConsensus contract.
@@ -738,6 +857,22 @@ contract DaveAppFactoryTest is Test {
         revert("Successful claim");
     }
 
+    /// @notice This function is used to simulate a foreclosure and a sentry rotation.
+    /// If the rotation succeeds, then the function reverts with error message "Successful rotation".
+    /// If the rotation fails, then the function propagates the error from the DaveConsensus contract.
+    function simulateForeclosureAndRotation(
+        IApplication appContract,
+        IDaveConsensus daveConsensus,
+        address currentSentry,
+        address newSentry
+    ) external {
+        vm.prank(appContract.getGuardian());
+        appContract.foreclose();
+        vm.prank(daveConsensus.getSentryManager());
+        daveConsensus.rotateSentry(currentSentry, newSentry);
+        revert("Successful rotation");
+    }
+
     /// @notice This function is used to simulate a foreclosure and a tournament-result acceptance.
     /// If the acceptance succeeds, then the function reverts with error message "Successful acceptance".
     /// If the acceptance fails, then the function propagates the error from the DaveConsensus contract.
@@ -756,6 +891,7 @@ contract DaveAppFactoryTest is Test {
     function _testNewDaveAppSuccess(
         bytes32 templateHash,
         uint64 claimStagingPeriod,
+        address sentryManager,
         address[] calldata sentries,
         WithdrawalConfig calldata withdrawalConfig,
         IApplication appContract,
@@ -961,6 +1097,7 @@ contract DaveAppFactoryTest is Test {
         assertEq(address(daveConsensus.getApplicationContract()), address(appContract));
         assertEq(address(daveConsensus.getTournamentFactory()), address(_tournamentFactory));
         assertEq(daveConsensus.getClaimStagingPeriod(), claimStagingPeriod);
+        assertEq(daveConsensus.getSentryManager(), sentryManager);
         assertEq(_getSentries(daveConsensus), sentries);
         assertEq(daveConsensus.getDeploymentBlockNumber(), vm.getBlockNumber());
         assertTrue(daveConsensus.supportsInterface(type(IERC165).interfaceId));
@@ -970,14 +1107,7 @@ contract DaveAppFactoryTest is Test {
         assertEq(daveConsensus.getLastFinalizedMachineMerkleRoot(address(appContract)), bytes32(0));
         assertFalse(daveConsensus.isOutputsMerkleRootValid(address(appContract), bytes32(vm.randomUint())));
 
-        address notAppContract;
-
-        while (true) {
-            notAppContract = vm.randomAddress();
-            if (notAppContract != address(appContract)) {
-                break;
-            }
-        }
+        address notAppContract = _randomAddressNotEq(address(appContract));
 
         vm.expectRevert(_encodeApplicationMismatch(address(appContract), notAppContract));
         daveConsensus.getLastFinalizedMachineMerkleRoot(notAppContract);
@@ -1180,6 +1310,14 @@ contract DaveAppFactoryTest is Test {
         daveConsensus.submitSentryClaim(epochNumber, Machine.Hash.wrap(bytes32(vm.randomUint())));
     }
 
+    function _encodeDuplicatedSentryAddress(uint256 sentryId, address sentry)
+        internal
+        pure
+        returns (bytes memory encodedError)
+    {
+        return abi.encodeWithSelector(ISentryErrors.DuplicatedSentryAddress.selector, sentryId, sentry);
+    }
+
     function _encodeApplicationMismatch(address expected, address obtained)
         internal
         pure
@@ -1238,6 +1376,14 @@ contract DaveAppFactoryTest is Test {
         return abi.encodeWithSelector(IDaveConsensus.CallerIsNotSentry.selector, caller);
     }
 
+    function _encodeCallerIsNotSentryManager(address caller) internal pure returns (bytes memory encodedError) {
+        return abi.encodeWithSelector(IDaveConsensus.CallerIsNotSentryManager.selector, caller);
+    }
+
+    function _encodeCannotRotateNonSentry(address nonSentry) internal pure returns (bytes memory encodedError) {
+        return abi.encodeWithSelector(IDaveConsensus.CannotRotateNonSentry.selector, nonSentry);
+    }
+
     function _randomUintNotEq(uint256 n) internal returns (uint256 m) {
         while (true) {
             m = vm.randomUint();
@@ -1265,10 +1411,28 @@ contract DaveAppFactoryTest is Test {
         }
     }
 
+    function _randomAddressNotEq(address n) internal returns (address m) {
+        while (true) {
+            m = vm.randomAddress();
+            if (n != m) {
+                break;
+            }
+        }
+    }
+
     function _randomNonSentry(IDaveConsensus daveConsensus) internal returns (address nonSentry) {
         while (true) {
             nonSentry = vm.randomAddress();
             if (daveConsensus.getSentryId(nonSentry) == 0) {
+                break;
+            }
+        }
+    }
+
+    function _randomValidNonSentry(IDaveConsensus daveConsensus) internal returns (address nonSentry) {
+        while (true) {
+            nonSentry = _randomNonSentry(daveConsensus);
+            if (nonSentry != address(0)) {
                 break;
             }
         }

--- a/cartesi-rollups/node/blockchain-reader/src/test_utils.rs
+++ b/cartesi-rollups/node/blockchain-reader/src/test_utils.rs
@@ -5,6 +5,7 @@ use alloy::{
     node_bindings::{Anvil, AnvilInstance},
     primitives::Address,
     primitives::FixedBytes,
+    primitives::U256,
     providers::{DynProvider, Provider, ProviderBuilder},
     signers::{Signer, local::PrivateKeySigner},
 };
@@ -88,6 +89,8 @@ pub async fn spawn_anvil_and_provider() -> Result<(AnvilInstance, DynProvider, A
             .expect("failed to read machine root hash")
     };
 
+    let claim_staging_period = U256::from(0);
+
     let withdrawal_config = WithdrawalConfig {
         guardian: Default::default(),
         log2LeavesPerAccount: Default::default(),
@@ -100,7 +103,12 @@ pub async fn spawn_anvil_and_provider() -> Result<(AnvilInstance, DynProvider, A
 
     let dave_app_factory_contract = IDaveAppFactory::new(dave_app_factory, &provider);
     let (app, consensus) = dave_app_factory_contract
-        .calculateDaveAppAddress(initial_hash.into(), withdrawal_config.clone(), salt)
+        .calculateDaveAppAddress(
+            initial_hash.into(),
+            claim_staging_period,
+            withdrawal_config.clone(),
+            salt,
+        )
         .call()
         .await
         .expect("failed to calculate Dave app addresses")
@@ -108,7 +116,12 @@ pub async fn spawn_anvil_and_provider() -> Result<(AnvilInstance, DynProvider, A
         .unwrap();
 
     dave_app_factory_contract
-        .newDaveApp(initial_hash.into(), withdrawal_config.clone(), salt)
+        .newDaveApp(
+            initial_hash.into(),
+            claim_staging_period,
+            withdrawal_config.clone(),
+            salt,
+        )
         .send()
         .await?
         .watch()

--- a/cartesi-rollups/node/blockchain-reader/src/test_utils.rs
+++ b/cartesi-rollups/node/blockchain-reader/src/test_utils.rs
@@ -92,6 +92,8 @@ pub async fn spawn_anvil_and_provider() -> Result<(AnvilInstance, DynProvider, A
 
     let claim_staging_period = U256::from(1000);
 
+    let sentry_manager = Address::ZERO;
+
     let sentries = vec![signer_address];
 
     let withdrawal_config = WithdrawalConfig {
@@ -109,6 +111,7 @@ pub async fn spawn_anvil_and_provider() -> Result<(AnvilInstance, DynProvider, A
         .calculateDaveAppAddress(
             initial_hash.into(),
             claim_staging_period,
+            sentry_manager,
             sentries.clone(),
             withdrawal_config.clone(),
             salt,
@@ -123,6 +126,7 @@ pub async fn spawn_anvil_and_provider() -> Result<(AnvilInstance, DynProvider, A
         .newDaveApp(
             initial_hash.into(),
             claim_staging_period,
+            sentry_manager,
             sentries.clone(),
             withdrawal_config.clone(),
             salt,

--- a/cartesi-rollups/node/blockchain-reader/src/test_utils.rs
+++ b/cartesi-rollups/node/blockchain-reader/src/test_utils.rs
@@ -64,6 +64,7 @@ pub async fn spawn_anvil_and_provider() -> Result<(AnvilInstance, DynProvider, A
     let mut signer: PrivateKeySigner = anvil.keys()[0].clone().into();
 
     signer.set_chain_id(Some(anvil.chain_id()));
+    let signer_address = signer.address();
     let wallet = EthereumWallet::from(signer);
 
     let provider = ProviderBuilder::new()
@@ -89,7 +90,9 @@ pub async fn spawn_anvil_and_provider() -> Result<(AnvilInstance, DynProvider, A
             .expect("failed to read machine root hash")
     };
 
-    let claim_staging_period = U256::from(0);
+    let claim_staging_period = U256::from(1000);
+
+    let sentries = vec![signer_address];
 
     let withdrawal_config = WithdrawalConfig {
         guardian: Default::default(),
@@ -106,6 +109,7 @@ pub async fn spawn_anvil_and_provider() -> Result<(AnvilInstance, DynProvider, A
         .calculateDaveAppAddress(
             initial_hash.into(),
             claim_staging_period,
+            sentries.clone(),
             withdrawal_config.clone(),
             salt,
         )
@@ -119,6 +123,7 @@ pub async fn spawn_anvil_and_provider() -> Result<(AnvilInstance, DynProvider, A
         .newDaveApp(
             initial_hash.into(),
             claim_staging_period,
+            sentries.clone(),
             withdrawal_config.clone(),
             salt,
         )

--- a/cartesi-rollups/node/cartesi-rollups-prt-node/src/lib.rs
+++ b/cartesi-rollups/node/cartesi-rollups-prt-node/src/lib.rs
@@ -95,6 +95,7 @@ pub fn create_epoch_manager_task(watch: Watch, parameters: &PRTConfig) -> thread
                     let epoch_manager = EpochManager::new(
                         Arc::new(Mutex::new(arena_sender)),
                         params.address_book.consensus,
+                        params.signer_address,
                         state_manager,
                         params.sleep_duration,
                         params.long_block_range_error_codes.clone(),

--- a/cartesi-rollups/node/epoch-manager/src/lib.rs
+++ b/cartesi-rollups/node/epoch-manager/src/lib.rs
@@ -24,6 +24,7 @@ use rollups_state_manager::{Epoch, Proof, StateManager, sync::Watch};
 pub struct EpochManager<AS: ArenaSender, SM: StateManager> {
     arena_sender: Arc<Mutex<AS>>,
     consensus: Address,
+    signer_address: Address,
     sleep_duration: Duration,
     long_block_range_error_codes: Vec<String>,
     state_manager: SM,
@@ -34,6 +35,7 @@ impl<AS: ArenaSender, SM: StateManager> EpochManager<AS, SM> {
     pub fn new(
         arena_sender: Arc<Mutex<AS>>,
         consensus_address: Address,
+        signer_address: Address,
         state_manager: SM,
         sleep_duration: Duration,
         long_block_range_error_codes: Vec<String>,
@@ -41,6 +43,7 @@ impl<AS: ArenaSender, SM: StateManager> EpochManager<AS, SM> {
         Self {
             arena_sender,
             consensus: consensus_address,
+            signer_address,
             sleep_duration,
             long_block_range_error_codes,
             state_manager,
@@ -68,9 +71,93 @@ impl<AS: ArenaSender, SM: StateManager> EpochManager<AS, SM> {
             alloy::network::Ethereum,
         >,
     ) -> Result<()> {
+        self.try_submit_sentry_claim(dave_consensus).await?;
         self.try_stage_tournament_result(dave_consensus).await?;
-        self.try_accept_staged_tournament_result(dave_consensus)
+        self.try_accept_tournament_result(dave_consensus).await?;
+        Ok(())
+    }
+
+    async fn try_submit_sentry_claim(
+        &mut self,
+        dave_consensus: &DaveConsensus::DaveConsensusInstance<
+            DynProvider,
+            alloy::network::Ethereum,
+        >,
+    ) -> Result<()> {
+        let sentry_id = dave_consensus
+            .getSentryId(self.signer_address)
+            .block(alloy::eips::BlockId::pending())
+            .call()
             .await?;
+
+        if sentry_id == 0 {
+            trace!(
+                "signer {} is not a sentry of DaveConsensus@{}",
+                self.signer_address,
+                dave_consensus.address()
+            );
+            return Ok(());
+        }
+
+        let current_sealed_epoch = dave_consensus
+            .getCurrentSealedEpoch()
+            .block(alloy::eips::BlockId::pending())
+            .call()
+            .await?;
+
+        let epoch_number = current_sealed_epoch.epochNumber;
+
+        let has_voted = dave_consensus
+            .hasSentryClaimedInEpoch(epoch_number, sentry_id)
+            .block(alloy::eips::BlockId::pending())
+            .call()
+            .await?;
+
+        if has_voted {
+            trace!(
+                "sentry {} (id {}) has already voted for epoch {} of DaveConsensus@{}",
+                self.signer_address,
+                sentry_id,
+                epoch_number,
+                dave_consensus.address()
+            );
+            return Ok(());
+        }
+
+        let can_accept = dave_consensus
+            .canAcceptStagedTournamentResult()
+            .block(alloy::eips::BlockId::pending())
+            .call()
+            .await?;
+
+        if can_accept.isTournamentResultStaged && can_accept.isClaimStagingPeriodOver {
+            trace!(
+                "epoch {} already has a staged tournament result past its staging period",
+                epoch_number
+            );
+            return Ok(());
+        }
+
+        match self.state_manager.settlement_info(
+            epoch_number
+                .to_u64()
+                .expect("fail to convert epoch number to u64"),
+        )? {
+            Some(settlement) => {
+                let claim = vec_u8_to_bytes_32(settlement.final_state.into());
+
+                info!("submit sentry claim {} for epoch {}", claim, epoch_number);
+                let tx_result = dave_consensus
+                    .submitSentryClaim(epoch_number, claim)
+                    .send()
+                    .await;
+
+                allow_revert_rethrow_others("submitSentryClaim", tx_result).await?;
+            }
+            None => {
+                trace!("wait for the `machine-runner` to insert the value");
+            }
+        }
         Ok(())
     }
 
@@ -100,6 +187,10 @@ impl<AS: ArenaSender, SM: StateManager> EpochManager<AS, SM> {
                         can_stage.winnerCommitment,
                         "Winner commitment mismatch, notify all users!"
                     );
+                    assert_eq!(
+                        settlement.final_state, can_stage.winnerPostEpochMachineStateHash,
+                        "Winner final state mismatch, notify all users!"
+                    );
                     info!(
                         "stage tournament result of epoch {} with claim {}",
                         can_stage.epochNumber,
@@ -125,7 +216,7 @@ impl<AS: ArenaSender, SM: StateManager> EpochManager<AS, SM> {
         Ok(())
     }
 
-    async fn try_accept_staged_tournament_result(
+    async fn try_accept_tournament_result(
         &mut self,
         dave_consensus: &DaveConsensus::DaveConsensusInstance<
             DynProvider,
@@ -138,7 +229,7 @@ impl<AS: ArenaSender, SM: StateManager> EpochManager<AS, SM> {
             .call()
             .await?;
 
-        if can_accept.isTournamentResultStaged && can_accept.isClaimStagingPeriodOver {
+        if can_accept.isTournamentResultStaged {
             match self.state_manager.settlement_info(
                 can_accept
                     .epochNumber
@@ -147,19 +238,29 @@ impl<AS: ArenaSender, SM: StateManager> EpochManager<AS, SM> {
             )? {
                 Some(settlement) => {
                     assert_eq!(
+                        vec_u8_to_bytes_32(settlement.final_state.into()),
+                        can_accept.stagedPostEpochMachineStateHash,
+                        "Staged final state mismatch, notify all users!"
+                    );
+                    assert_eq!(
                         vec_u8_to_bytes_32(settlement.output_merkle.into()),
                         can_accept.stagedPostEpochOutputsMerkleRoot,
                         "Staged outputs Merkle root mismatch, notify all users!"
                     );
-                    info!(
-                        "accept staged tournament result of epoch {}",
-                        can_accept.epochNumber
-                    );
-                    let tx_result = dave_consensus
-                        .acceptStagedTournamentResult(can_accept.epochNumber)
-                        .send()
-                        .await;
-                    allow_revert_rethrow_others("acceptStagedTournamentResult", tx_result).await?;
+                    if can_accept.doAllSentriesAgreeWithStagedTournamentResult
+                        || can_accept.isClaimStagingPeriodOver
+                    {
+                        info!(
+                            "accept staged tournament result of epoch {}",
+                            can_accept.epochNumber
+                        );
+                        let tx_result = dave_consensus
+                            .acceptStagedTournamentResult(can_accept.epochNumber)
+                            .send()
+                            .await;
+                        allow_revert_rethrow_others("acceptStagedTournamentResult", tx_result)
+                            .await?;
+                    }
                 }
                 None => {
                     trace!("wait for the `machine-runner` to insert the value");

--- a/cartesi-rollups/node/epoch-manager/src/lib.rs
+++ b/cartesi-rollups/node/epoch-manager/src/lib.rs
@@ -68,15 +68,28 @@ impl<AS: ArenaSender, SM: StateManager> EpochManager<AS, SM> {
             alloy::network::Ethereum,
         >,
     ) -> Result<()> {
-        let can_settle = dave_consensus
-            .canSettle()
+        self.try_stage_tournament_result(dave_consensus).await?;
+        self.try_accept_staged_tournament_result(dave_consensus)
+            .await?;
+        Ok(())
+    }
+
+    async fn try_stage_tournament_result(
+        &mut self,
+        dave_consensus: &DaveConsensus::DaveConsensusInstance<
+            DynProvider,
+            alloy::network::Ethereum,
+        >,
+    ) -> Result<()> {
+        let can_stage = dave_consensus
+            .canStageTournamentResult()
             .block(alloy::eips::BlockId::pending())
             .call()
             .await?;
 
-        if can_settle.isFinished {
+        if can_stage.isFinished && !can_stage.isTournamentResultStaged {
             match self.state_manager.settlement_info(
-                can_settle
+                can_stage
                     .epochNumber
                     .to_u64()
                     .expect("fail to convert epoch number to u64"),
@@ -84,30 +97,76 @@ impl<AS: ArenaSender, SM: StateManager> EpochManager<AS, SM> {
                 Some(settlement) => {
                     assert_eq!(
                         settlement.computation_hash.data(),
-                        can_settle.winnerCommitment,
+                        can_stage.winnerCommitment,
                         "Winner commitment mismatch, notify all users!"
                     );
                     info!(
-                        "settle epoch {} with claim {}",
-                        can_settle.epochNumber,
+                        "stage tournament result of epoch {} with claim {}",
+                        can_stage.epochNumber,
                         settlement.computation_hash.to_hex()
                     );
                     let tx_result = dave_consensus
-                        .settle(
-                            can_settle.epochNumber,
+                        .stageTournamentResult(
+                            can_stage.epochNumber,
                             vec_u8_to_bytes_32(settlement.output_merkle.into()),
                             to_bytes_32_vec(settlement.output_proof),
                         )
                         .send()
                         .await;
-                    allow_revert_rethrow_others("settle", tx_result).await?;
+                    allow_revert_rethrow_others("stageTournamentResult", tx_result).await?;
                 }
                 None => {
                     trace!("wait for the `machine-runner` to insert the value");
                 }
             }
         } else {
-            trace!("epoch not ready to be settled");
+            trace!("tournament result not ready to be staged");
+        }
+        Ok(())
+    }
+
+    async fn try_accept_staged_tournament_result(
+        &mut self,
+        dave_consensus: &DaveConsensus::DaveConsensusInstance<
+            DynProvider,
+            alloy::network::Ethereum,
+        >,
+    ) -> Result<()> {
+        let can_accept = dave_consensus
+            .canAcceptStagedTournamentResult()
+            .block(alloy::eips::BlockId::pending())
+            .call()
+            .await?;
+
+        if can_accept.isTournamentResultStaged && can_accept.isClaimStagingPeriodOver {
+            match self.state_manager.settlement_info(
+                can_accept
+                    .epochNumber
+                    .to_u64()
+                    .expect("fail to convert epoch number to u64"),
+            )? {
+                Some(settlement) => {
+                    assert_eq!(
+                        vec_u8_to_bytes_32(settlement.output_merkle.into()),
+                        can_accept.stagedPostEpochOutputsMerkleRoot,
+                        "Staged outputs Merkle root mismatch, notify all users!"
+                    );
+                    info!(
+                        "accept staged tournament result of epoch {}",
+                        can_accept.epochNumber
+                    );
+                    let tx_result = dave_consensus
+                        .acceptStagedTournamentResult(can_accept.epochNumber)
+                        .send()
+                        .await;
+                    allow_revert_rethrow_others("acceptStagedTournamentResult", tx_result).await?;
+                }
+                None => {
+                    trace!("wait for the `machine-runner` to insert the value");
+                }
+            }
+        } else {
+            trace!("staged tournament result not ready to be accepted");
         }
         Ok(())
     }

--- a/cartesi-rollups/node/state-manager/src/lib.rs
+++ b/cartesi-rollups/node/state-manager/src/lib.rs
@@ -65,6 +65,7 @@ impl Proof {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Settlement {
     pub computation_hash: Digest,
+    pub final_state: Hash,
     pub output_merkle: Hash,
     pub output_proof: Proof,
 }

--- a/cartesi-rollups/node/state-manager/src/persistent_state_access.rs
+++ b/cartesi-rollups/node/state-manager/src/persistent_state_access.rs
@@ -12,6 +12,7 @@ use crate::{
 
 use alloy::primitives::U256;
 use cartesi_dave_merkle::{Digest, MerkleBuilder};
+use cartesi_machine::types::Hash;
 use rusqlite::Connection;
 
 #[derive(Debug)]
@@ -212,7 +213,7 @@ impl StateManager for PersistentStateAccess {
         let settlement = {
             let leafs = rollup_data::get_all_commitments(&self.connection, previous_epoch_number)?;
 
-            let computation_hash = if !leafs.is_empty() {
+            let (computation_hash, final_state) = if !leafs.is_empty() {
                 build_commitment_from_hashes(&leafs)
             } else {
                 assert_eq!(machine.next_input_index_in_epoch(), 0);
@@ -226,6 +227,7 @@ impl StateManager for PersistentStateAccess {
 
             Settlement {
                 computation_hash,
+                final_state,
                 output_merkle,
                 output_proof,
             }
@@ -286,7 +288,7 @@ impl StateManager for PersistentStateAccess {
     }
 }
 
-fn build_commitment_from_hashes(state_hashes: &[CommitmentLeaf]) -> Digest {
+fn build_commitment_from_hashes(state_hashes: &[CommitmentLeaf]) -> (Digest, Hash) {
     let mut builder = MerkleBuilder::default();
 
     assert!(!state_hashes.is_empty());
@@ -306,7 +308,7 @@ fn build_commitment_from_hashes(state_hashes: &[CommitmentLeaf]) -> Digest {
     );
 
     let tree = builder.build();
-    tree.root_hash()
+    (tree.root_hash(), last.hash)
 }
 
 #[cfg(test)]
@@ -526,13 +528,14 @@ mod tests {
         access.roll_epoch()?;
         assert_eq!(access.latest_snapshot()?.epoch(), 1);
 
+        let (computation_hash, final_state) =
+            build_commitment_from_hashes(&[commitment_leaf_1.clone(), commitment_leaf_2.clone()]);
+
         assert_eq!(
             access.settlement_info(0)?.unwrap(),
             Settlement {
-                computation_hash: build_commitment_from_hashes(&[
-                    commitment_leaf_1.clone(),
-                    commitment_leaf_2.clone()
-                ]),
+                computation_hash,
+                final_state,
                 output_merkle,
                 output_proof
             },

--- a/cartesi-rollups/node/state-manager/src/sql/migrations.sql
+++ b/cartesi-rollups/node/state-manager/src/sql/migrations.sql
@@ -4,6 +4,7 @@
 CREATE TABLE IF NOT EXISTS settlement_info (
     epoch_number INTEGER NOT NULL PRIMARY KEY CHECK (epoch_number >= 0),
     computation_hash BLOB NOT NULL,
+    final_state BLOB NOT NULL,
     output_merkle BLOB NOT NULL,
     output_proof BLOB NOT NULL
 );

--- a/cartesi-rollups/node/state-manager/src/sql/rollup_data.rs
+++ b/cartesi-rollups/node/state-manager/src/sql/rollup_data.rs
@@ -29,16 +29,21 @@ fn convert_row_to_settlement(row: &rusqlite::Row) -> rusqlite::Result<Settlement
         .expect("computation_hash must be 32 bytes");
     let computation_hash = ch_arr.into();
 
+    // final_state blob -> [u8;32]
+    let fs_blob: Vec<u8> = row.get(1)?;
+    let final_state: Hash = fs_blob.try_into().expect("final_state must be 32 bytes");
+
     // output_merkle blob -> [u8;32]
-    let om_blob: Vec<u8> = row.get(1)?;
+    let om_blob: Vec<u8> = row.get(2)?;
     let output_merkle: Hash = om_blob.try_into().expect("output_merkle must be 32 bytes");
 
     // output_proof blob -> Proof
-    let proof_blob: Vec<u8> = row.get(2)?;
+    let proof_blob: Vec<u8> = row.get(3)?;
     let output_proof = Proof::from_flattened(proof_blob);
 
     Ok(Settlement {
         computation_hash,
+        final_state,
         output_merkle,
         output_proof,
     })
@@ -108,7 +113,7 @@ pub fn settlement_info(conn: &Connection, epoch_number: u64) -> Result<Option<Se
     let mut stmt = conn
         .prepare_cached(
             r#"
-            SELECT computation_hash, output_merkle, output_proof
+            SELECT computation_hash, final_state, output_merkle, output_proof
             FROM settlement_info
             WHERE epoch_number = ?1
             "#,
@@ -132,8 +137,8 @@ pub fn insert_settlement_info(
         .prepare_cached(
             r#"
             INSERT INTO settlement_info
-            (epoch_number, computation_hash, output_merkle, output_proof)
-            VALUES (?1, ?2, ?3, ?4)
+            (epoch_number, computation_hash, final_state, output_merkle, output_proof)
+            VALUES (?1, ?2, ?3, ?4, ?5)
             "#,
         )
         .map_err(anyhow::Error::from)?;
@@ -142,6 +147,7 @@ pub fn insert_settlement_info(
         .execute(params![
             epoch_number,
             settlement.computation_hash.data(),
+            &settlement.final_state,
             &settlement.output_merkle,
             &settlement.output_proof.flatten(),
         ])
@@ -417,7 +423,8 @@ mod tests {
         let (_handle, conn) = setup_db();
         let settlement = Settlement {
             computation_hash: [0xAA; 32].into(),
-            output_merkle: [0xBB; 32],
+            final_state: [0xBB; 32],
+            output_merkle: [0xCC; 32],
             output_proof: Proof::new(vec![[0; 32]]),
         };
         insert_settlement_info(&conn, &settlement, 42).unwrap();
@@ -430,7 +437,8 @@ mod tests {
         let (_handle, conn) = setup_db();
         let settlement = Settlement {
             computation_hash: [0x11; 32].into(),
-            output_merkle: [0x22; 32],
+            final_state: [0x22; 32],
+            output_merkle: [0x33; 32],
             output_proof: Proof::new(vec![[0; 32]]),
         };
         insert_settlement_info(&conn, &settlement, 55).unwrap();

--- a/prt/client-rs/core/src/tournament/sender.rs
+++ b/prt/client-rs/core/src/tournament/sender.rs
@@ -132,8 +132,13 @@ impl ArenaSender for EthArenaSender {
             .map(|h| -> B256 { (*h).into() })
             .collect();
         trace!(
-            "final state for tournament {} at position {}",
-            proof.node, proof.position
+            "join tournament {:?} with final_state {} at position {}, left {}, right {}, proof_len {}",
+            tournament,
+            proof.node,
+            proof.position,
+            left_child,
+            right_child,
+            proof.siblings.len()
         );
         let tx_result = tournament
             .joinTournament(

--- a/prt/contracts/src/tournament/libs/Match.sol
+++ b/prt/contracts/src/tournament/libs/Match.sol
@@ -195,10 +195,7 @@ library Match {
         return args.toCycle(state.runningLeafPosition);
     }
 
-    function getDivergence(
-        State memory state,
-        Commitment.Arguments memory args
-    )
+    function getDivergence(State memory state, Commitment.Arguments memory args)
         internal
         pure
         returns (

--- a/prt/tests/rollups/dave/node.lua
+++ b/prt/tests/rollups/dave/node.lua
@@ -4,6 +4,7 @@ local Machine = require "computation.machine"
 local helper = require "utils.helper"
 local time = require "utils.time"
 
+local ANVIL_ADDRESS_7 = "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"
 local ANVIL_KEY_7 = "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
 
 local function start_dave_node(machine_path, app_address, db_path, sleep_duration, verbosity, trace_level)
@@ -32,6 +33,7 @@ end
 
 local Dave = {}
 Dave.__index = Dave
+Dave.wallet_address = ANVIL_ADDRESS_7
 
 function Dave:new(machine_path, app_address, sender, sleep_duration, verbosity, trace_level)
     -- trace, debug, info, warn, error

--- a/prt/tests/rollups/dave/reader.lua
+++ b/prt/tests/rollups/dave/reader.lua
@@ -280,12 +280,13 @@ function Reader:balance(address)
 end
 
 function Reader:calculate_dave_app_address(template_hash, sentries, salt)
-    local sig = "calculateDaveAppAddress(bytes32,uint256,address[],(address,uint8,uint8,uint64,address),bytes32)(address,address)"
+    local sig = "calculateDaveAppAddress(bytes32,uint256,address,address[],(address,uint8,uint8,uint64,address),bytes32)(address,address)"
     local claim_staging_period = 1000
-    local sentries_str = "[" .. table.concat(sentries, ",") .. "]"
     local address_zero = "0x" .. string.rep("00", 20)
+    local sentry_manager = address_zero
+    local sentries_str = "[" .. table.concat(sentries, ",") .. "]"
     local withdrawal_config = string.format("(%s,0,0,0,%s)", address_zero, address_zero)
-    local ret = self:_call(self.dave_app_factory_address, sig, { template_hash, claim_staging_period, sentries_str, withdrawal_config, salt })
+    local ret = self:_call(self.dave_app_factory_address, sig, { template_hash, claim_staging_period, sentry_manager, sentries_str, withdrawal_config, salt })
     assert(#ret == 2)
     return table.unpack(ret)
 end

--- a/prt/tests/rollups/dave/reader.lua
+++ b/prt/tests/rollups/dave/reader.lua
@@ -205,7 +205,7 @@ end
 
 function Reader:read_epochs_sealed()
     local sig = "EpochSealed(uint256,uint256,uint256,bytes32,bytes32,address)"
-    local data_sig = "(uint256,uint256,uint256,bytes32,bytes32,address)"
+    local data_sig = "(uint256,uint256,bytes32,bytes32,address)"
 
     local logs = self:_read_logs(self.consensus_address, sig, { false, false, false }, data_sig)
 
@@ -214,11 +214,11 @@ function Reader:read_epochs_sealed()
         local log = {}
         log.meta = v.meta
 
-        log.epoch_number = tonumber(v.decoded_data[1])
-        log.input_lower_bound = tonumber(v.decoded_data[2])
-        log.input_upper_bound = tonumber(v.decoded_data[3])
-        log.initial_machine_state_hash = v.decoded_data[4]
-        log.tournament = v.decoded_data[6]
+        log.epoch_number = tonumber(v.emited_topics[2])
+        log.input_lower_bound = tonumber(v.decoded_data[1])
+        log.input_upper_bound = tonumber(v.decoded_data[2])
+        log.initial_machine_state_hash = v.decoded_data[3]
+        log.tournament = v.decoded_data[5]
 
         ret[k] = log
     end

--- a/prt/tests/rollups/dave/reader.lua
+++ b/prt/tests/rollups/dave/reader.lua
@@ -64,7 +64,7 @@ end
 local Reader = {}
 Reader.__index = Reader
 
-function Reader:new(input_box_address, dave_app_factory_address, template_hash, salt, endpoint, genesis)
+function Reader:new(input_box_address, dave_app_factory_address, template_hash, sentries, salt, endpoint, genesis)
     genesis = genesis or 0
     endpoint = endpoint or blockchain_constants.endpoint
     local reader = {
@@ -78,7 +78,7 @@ function Reader:new(input_box_address, dave_app_factory_address, template_hash, 
     setmetatable(reader, self)
 
     -- pre-calculate app and consensus addresses based on provided template hash and salt values
-    reader.app_address, reader.consensus_address = reader:calculate_dave_app_address(template_hash, salt)
+    reader.app_address, reader.consensus_address = reader:calculate_dave_app_address(template_hash, sentries, salt)
 
     return reader
 end
@@ -279,12 +279,13 @@ function Reader:balance(address)
     return uint256.new(balance)
 end
 
-function Reader:calculate_dave_app_address(template_hash, salt)
-    local sig = "calculateDaveAppAddress(bytes32,uint256,(address,uint8,uint8,uint64,address),bytes32)(address,address)"
-    local claim_staging_period = 0
+function Reader:calculate_dave_app_address(template_hash, sentries, salt)
+    local sig = "calculateDaveAppAddress(bytes32,uint256,address[],(address,uint8,uint8,uint64,address),bytes32)(address,address)"
+    local claim_staging_period = 1000
+    local sentries_str = "[" .. table.concat(sentries, ",") .. "]"
     local address_zero = "0x" .. string.rep("00", 20)
     local withdrawal_config = string.format("(%s,0,0,0,%s)", address_zero, address_zero)
-    local ret = self:_call(self.dave_app_factory_address, sig, { template_hash, claim_staging_period, withdrawal_config, salt })
+    local ret = self:_call(self.dave_app_factory_address, sig, { template_hash, claim_staging_period, sentries_str, withdrawal_config, salt })
     assert(#ret == 2)
     return table.unpack(ret)
 end

--- a/prt/tests/rollups/dave/reader.lua
+++ b/prt/tests/rollups/dave/reader.lua
@@ -280,10 +280,11 @@ function Reader:balance(address)
 end
 
 function Reader:calculate_dave_app_address(template_hash, salt)
-    local sig = "calculateDaveAppAddress(bytes32,(address,uint8,uint8,uint64,address),bytes32)(address,address)"
+    local sig = "calculateDaveAppAddress(bytes32,uint256,(address,uint8,uint8,uint64,address),bytes32)(address,address)"
+    local claim_staging_period = 0
     local address_zero = "0x" .. string.rep("00", 20)
     local withdrawal_config = string.format("(%s,0,0,0,%s)", address_zero, address_zero)
-    local ret = self:_call(self.dave_app_factory_address, sig, { template_hash, withdrawal_config, salt })
+    local ret = self:_call(self.dave_app_factory_address, sig, { template_hash, claim_staging_period, withdrawal_config, salt })
     assert(#ret == 2)
     return table.unpack(ret)
 end

--- a/prt/tests/rollups/dave/sender.lua
+++ b/prt/tests/rollups/dave/sender.lua
@@ -113,15 +113,16 @@ function Sender:tx_add_inputs(inputs)
 end
 
 function Sender:tx_new_dave_app(template_hash, sentries, salt)
-    local sig = "newDaveApp(bytes32,uint256,address[],(address,uint8,uint8,uint64,address),bytes32)"
+    local sig = "newDaveApp(bytes32,uint256,address,address[],(address,uint8,uint8,uint64,address),bytes32)"
     local claim_staging_period = 1000
-    local sentries_str = "[" .. table.concat(sentries, ",") .. "]"
     local address_zero = "0x" .. string.rep("00", 20)
+    local sentry_manager = address_zero
+    local sentries_str = "[" .. table.concat(sentries, ",") .. "]"
     local withdrawal_config = string.format("(%s,0,0,0,%s)", address_zero, address_zero)
     return self:_send_tx(
         self.dave_app_factory_address,
         sig,
-        { template_hash, claim_staging_period, sentries_str, withdrawal_config, salt }
+        { template_hash, claim_staging_period, sentry_manager, sentries_str, withdrawal_config, salt }
     )
 end
 

--- a/prt/tests/rollups/dave/sender.lua
+++ b/prt/tests/rollups/dave/sender.lua
@@ -113,13 +113,14 @@ function Sender:tx_add_inputs(inputs)
 end
 
 function Sender:tx_new_dave_app(template_hash, salt)
-    local sig = "newDaveApp(bytes32,(address,uint8,uint8,uint64,address),bytes32)"
+    local sig = "newDaveApp(bytes32,uint256,(address,uint8,uint8,uint64,address),bytes32)"
+    local claim_staging_period = 0
     local address_zero = "0x" .. string.rep("00", 20)
     local withdrawal_config = string.format("(%s,0,0,0,%s)", address_zero, address_zero)
     return self:_send_tx(
         self.dave_app_factory_address,
         sig,
-        { template_hash, withdrawal_config, salt }
+        { template_hash, claim_staging_period, withdrawal_config, salt }
     )
 end
 

--- a/prt/tests/rollups/dave/sender.lua
+++ b/prt/tests/rollups/dave/sender.lua
@@ -112,15 +112,16 @@ function Sender:tx_add_inputs(inputs)
     end
 end
 
-function Sender:tx_new_dave_app(template_hash, salt)
-    local sig = "newDaveApp(bytes32,uint256,(address,uint8,uint8,uint64,address),bytes32)"
-    local claim_staging_period = 0
+function Sender:tx_new_dave_app(template_hash, sentries, salt)
+    local sig = "newDaveApp(bytes32,uint256,address[],(address,uint8,uint8,uint64,address),bytes32)"
+    local claim_staging_period = 1000
+    local sentries_str = "[" .. table.concat(sentries, ",") .. "]"
     local address_zero = "0x" .. string.rep("00", 20)
     local withdrawal_config = string.format("(%s,0,0,0,%s)", address_zero, address_zero)
     return self:_send_tx(
         self.dave_app_factory_address,
         sig,
-        { template_hash, claim_staging_period, withdrawal_config, salt }
+        { template_hash, claim_staging_period, sentries_str, withdrawal_config, salt }
     )
 end
 

--- a/prt/tests/rollups/test_env.lua
+++ b/prt/tests/rollups/test_env.lua
@@ -56,13 +56,14 @@ function Env.spawn_blockchain(inputs)
 
     local blockchain = Blockchain:new(ANVIL_LOAD_PATH, ANVIL_DUMP_PATH)
     Env.blockchain = blockchain
-    Env.reader = Reader:new(INPUT_BOX_ADDRESS, DAVE_APP_FACTORY_ADDRESS, TEMPLATE_MACHINE_HASH, SALT, blockchain
+    Env.sentries = {Dave.wallet_address}
+    Env.reader = Reader:new(INPUT_BOX_ADDRESS, DAVE_APP_FACTORY_ADDRESS, TEMPLATE_MACHINE_HASH, Env.sentries, SALT, blockchain
         .endpoint)
     Env.app_address = Env.reader.app_address
     Env.consensus_address = Env.reader.consensus_address
     Env.sender = Sender:new(INPUT_BOX_ADDRESS, DAVE_APP_FACTORY_ADDRESS, Env.app_address, blockchain.pks[1],
         blockchain.endpoint)
-    Env.sender:tx_new_dave_app(TEMPLATE_MACHINE_HASH, SALT)
+    Env.sender:tx_new_dave_app(TEMPLATE_MACHINE_HASH, Env.sentries, SALT)
     Env.sender:tx_add_inputs(inputs)
     Env.sender:advance_blocks(2)
     return blockchain

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -2,7 +2,7 @@
 
 ARG RUST_VERSION=1.90
 ARG DEBIAN_VERSION=trixie
-ARG FOUNDRY_VERSION=1.4.3
+ARG FOUNDRY_VERSION=1.5.1
 ARG PNPM_VERSION=10.7.0
 ARG JUST_VERSION=1.46.0
 
@@ -39,8 +39,8 @@ RUN <<EOF
 curl -fsSL https://github.com/foundry-rs/foundry/releases/download/v${FOUNDRY_VERSION}/foundry_v${FOUNDRY_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz \
   -o /tmp/foundry.tar.gz
 case "${TARGETARCH}" in
-    amd64) echo "325ba04dc5cb41c110723b00ac291f8269f8cd785028299aad8252ef980961a7 /tmp/foundry.tar.gz" | sha256sum --check ;;
-    arm64) echo "209492cb4ebd723d9eac002fa30f41f53c8810105b67d3c32fe8201cf70f89d4 /tmp/foundry.tar.gz" | sha256sum --check ;;
+    amd64) echo "73640b01bd9ed29fdb4965085099371f8cf0dbbec3e2086cf54564efc4dcfe88 /tmp/foundry.tar.gz" | sha256sum --check ;;
+    arm64) echo "cccf28bdf202289e837a9e21ed213b2b80dc1e806e12f1717bc98a44315c331e /tmp/foundry.tar.gz" | sha256sum --check ;;
     *) echo "unsupported architecture: ${TARGETARCH}"; exit 1 ;;
 esac
 tar -zx -f /tmp/foundry.tar.gz -C /usr/local/bin

--- a/test/programs/justfile
+++ b/test/programs/justfile
@@ -33,7 +33,7 @@ clean-echo: (clean-program "echo")
 # honeypot/honeypot (requires docker)
 build-honeypot-snapshot: clean-honeypot-snapshot clean-honeypot-project
   git clone https://github.com/cartesi/honeypot.git honeypot/project
-  git -C honeypot/project reset --hard 34d00721a527eeb7ed8cce2a13a142e3d8de9aad # v3.0.0
+  git -C honeypot/project reset --hard 589a9c1a26522904f79df4955caff69537d38b13 # v3.0.1
   sed -i 's/,filename:/,data_filename:/g' honeypot/project/Makefile
   sed -i 's/--append-bootargs=ro/--append-bootargs=rw/g' honeypot/project/Makefile
   sed -i 's/label:state,length:4096,user:dapp/label:state,length:4096,user:dapp,mke2fs:false,mount:false/g' honeypot/project/Makefile


### PR DESCRIPTION
## Summary

This PR introduces claim staging to `DaveConsensus`: instead of settling an epoch in a single transaction, the tournament result is first *staged* and only *accepted* (settling the epoch) after either a configurable claim staging period has elapsed or all designated **sentries** have confirmed the result. This adds a safety window in which independent validators can cross-check a tournament's outcome before it becomes final, while still allowing fast settlement when all sentries agree. To ensure early epoch settlement, a designated sentry manager can rotate sentries if any of their credentials are compromised.

Closes #137

## Changes

### Contracts
- Split `settle`/`canSettle` into staging and acceptance steps
- Anyone can stage a finished tournament's result; emits `EpochStaged`
- Staged results are accepted after the claim staging period elapses
- Acceptance is immediate if all sentries agree with the staged machine state hash
- Sentries are appointed upon deployment and assigned sequential IDs from 1 to N
- Sentries can be rotated by the sentry manager via `rotateSentry`; emits `SentryRotation`
- Sentries vouch for a post-epoch machine state hash via `submitSentryClaim`; emits `SentryClaim`
- New getters for the claim staging period, sentry manager and sentry-related state
- New errors for staging, acceptance, sentry rotations, and sentry claim requirements
- Added staging info to `getCurrentSealedEpoch` view function return values
- `IDaveAppFactory` functions take `claimStagingPeriod`, `sentryManager`, and `sentries`
- Tests extended to cover staging, sentry claims, sentry rotations, and acceptance
- Index `epochNumber` parameter in `EpochSealed` event
### Node
- `epoch-manager` updated to follow the new two-step flow with sentry claims
### Tests
- `blockchain-reader` test utils and the PRT rollups Lua test framework updated
### Chores
- Bump Foundry from 1.4.3 to 1.5.1
- Bump Honeypot from 3.0.0 to 3.0.1